### PR TITLE
Batch Request For Embeds

### DIFF
--- a/cohere/__init__.py
+++ b/cohere/__init__.py
@@ -3,6 +3,7 @@ from .error import CohereError
 
 COHERE_API_URL = 'https://api.cohere.ai'
 COHERE_VERSION = '2021-11-08'
+COHERE_BATCH_SIZE = 5
 GENERATE_URL = 'generate'
 EMBED_URL = 'embed'
 CHOOSE_BEST_URL = 'choose-best'

--- a/cohere/__init__.py
+++ b/cohere/__init__.py
@@ -3,7 +3,7 @@ from .error import CohereError
 
 COHERE_API_URL = 'https://api.cohere.ai'
 COHERE_VERSION = '2021-11-08'
-COHERE_BATCH_SIZE = 5
+COHERE_EMBED_BATCH_SIZE = 5
 GENERATE_URL = 'generate'
 EMBED_URL = 'embed'
 CHOOSE_BEST_URL = 'choose-best'

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -2,8 +2,12 @@ import json
 from typing import List, Any
 from urllib.parse import urljoin
 
+import math
+
 import requests
 from requests import Response
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import cohere
 from cohere.best_choices import BestChoices
@@ -13,10 +17,11 @@ from cohere.generation import Generations, Generation, TokenLikelihood
 from cohere.tokenize import Tokens
 
 class Client:
-    def __init__(self, api_key: str, version: str = None) -> None:
+    def __init__(self, api_key: str, version: str = None, num_workers: int = 8) -> None:
         self.api_key = api_key
         self.api_url = cohere.COHERE_API_URL
-        self.batch_size = cohere.COHERE_BATCH_SIZE
+        self.batch_size = cohere.COHERE_EMBED_BATCH_SIZE
+        self.num_workers = num_workers
         if version is None:
             self.cohere_version = cohere.COHERE_VERSION
         else:
@@ -101,14 +106,26 @@ class Client:
 
     def embed(self, model: str, texts: List[str], truncate: str = 'NONE') -> Embeddings:
         responses = []
+        json_bodys = []
+        request_futures = []
+        num_batch = int(math.ceil(len(texts)/self.batch_size))
+        embed_url_stacked = [cohere.EMBED_URL] * num_batch
+        model_stacked = [model] * num_batch
+
         for i in range(0, len(texts), self.batch_size):
-            text = texts[i:i+self.batch_size]
-            json_body = json.dumps({
-                'texts': text,
+            texts_batch = texts[i:i+self.batch_size]
+            json_bodys.append(json.dumps({
+                'texts': texts_batch,
                 'truncate': truncate,
-            })
-            response = self.__request(json_body, cohere.EMBED_URL, model)
-            responses.extend(response['embeddings'])
+            }))
+
+        with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
+            for i in executor.map(self.__request, json_bodys, embed_url_stacked, model_stacked):
+                request_futures.append(i)
+
+        for result in request_futures:
+            responses.extend(result['embeddings'])
+
         return Embeddings(responses)
 
     def choose_best(self, model: str, query: str, options: List[str], mode:  str = '') -> BestChoices:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 setuptools.setup(
     name='cohere',
-    version='1.1.0',
+    version='1.2.0',
     author='kipply',
     author_email='carol@cohere.ai',
     description='A Python library for the Cohere API',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -80,7 +80,7 @@ class TestEmbed(unittest.TestCase):
         self.assertEqual(len(prediction.embeddings[0]), 1024)
         self.assertEqual(len(prediction.embeddings[1]), 1024)
     
-    def test_success_longer_multiple_batches(self):
+    def test_success_multiple_batches(self):
         prediction = co.embed(
             model='small',
             texts=['co:here', 'cohere', "embed", "python", "golang", "typescript", "rust?", "ai", "nlp","neural"])
@@ -88,6 +88,49 @@ class TestEmbed(unittest.TestCase):
         for embed in prediction.embeddings:
             self.assertIsInstance(embed, list)
             self.assertEqual(len(embed), 1024)
+
+    def test_success_longer_multiple_batches_unaligned_batch(self):
+        prediction = co.embed(
+            model='small',
+            texts=['co:here', 'cohere', "embed", "python", "golang", "typescript", "rust?", "ai", "nlp", "neural", "nets"])
+        self.assertEqual(len(prediction.embeddings), 11)
+        for embed in prediction.embeddings:
+            self.assertIsInstance(embed, list)
+            self.assertEqual(len(embed), 1024)
+
+    def test_success_longer_multiple_batches(self):
+        prediction = co.embed(
+            model='small',
+            texts=['co:here', 'cohere', "embed", "python", "golang"] * 200)
+        self.assertEqual(len(prediction.embeddings), 200*5)
+        for embed in prediction.embeddings:
+            self.assertIsInstance(embed, list)
+            self.assertEqual(len(embed), 1024)
+
+    def test_success_multiple_batches_in_order(self):
+        textAll = []
+
+        text1 = ['co:here', 'cohere', "embed", "python", "golang"]
+        prediction1 = co.embed(
+            model='small',
+            texts=text1)
+
+        text2 = ['co:here', 'cohere', "embed", "python", "golang"]
+        prediction2 = co.embed(
+            model='small',
+            texts=text2)
+
+        text3 = ['co:here', 'cohere', "embed", "python", "golang"]
+        prediction3 = co.embed(
+            model='small',
+            texts=text3)
+
+        textAll = [*text1,*text2,*text3]
+        predictionExpected = [*prediction1, *prediction2, *prediction3]
+
+        predictionAcutal = co.embed(model='small',texts=textAll)
+
+        self.assertListEqual(predictionExpected,list(predictionAcutal))
 
     def test_invalid_texts(self):
         with self.assertRaises(cohere.CohereError):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -79,6 +79,15 @@ class TestEmbed(unittest.TestCase):
         self.assertIsInstance(prediction.embeddings[1], list)
         self.assertEqual(len(prediction.embeddings[0]), 1024)
         self.assertEqual(len(prediction.embeddings[1]), 1024)
+    
+    def test_success_longer_multiple_batches(self):
+        prediction = co.embed(
+            model='small',
+            texts=['co:here', 'cohere', "embed", "python", "golang", "typescript", "rust?", "ai", "nlp","neural"])
+        self.assertEqual(len(prediction.embeddings), 10)
+        for embed in prediction.embeddings:
+            self.assertIsInstance(embed, list)
+            self.assertEqual(len(embed), 1024)
 
     def test_invalid_texts(self):
         with self.assertRaises(cohere.CohereError):


### PR DESCRIPTION
# What it does
- [x] Add non-parallel Batch Embeds
- [x] Parallel Batch Embeds through python `Threading Workers`  or `concurrent.futures.ThreadPoolExecutor` (still researching to figure out which is better) 

## Design Decision
- chose thread executor over multi processing executor as it is IO-bound but CPU-bound so most of the time the threads are waiting for a network response
- the response must be in order (test added)

## Future PR
- [ ] add default num_workers depend on user's # of cores #46 
- [ ] exponential decay retrying #47 


## Tests
- [x] added unit tests for multiple batches
- [x] test that it is in order

## Basic Performance Test for 25k texts

- @jalammar reported it takes 5 hours for non-parallel

- batching resulted in 3mins & 30 secs

```python
letters = string.ascii_lowercase

def random_word():
    return ''.join(random.choice(letters) for i in range(10))

def random_sentence(num):
    sentence = ""

    for i in range(num):
        sentence += random_word()

    return sentence

def list_of_list(num):
    arr = []

    for i in range(num):
        arr.append(random_sentence(50))
    
    return arr

co = cohere.Client(
    API_KEY)

prediction = co.embed(
    model='small',
    texts=list_of_list(25000))

print(len(prediction.embeddings))
```