### PR TITLE
Add default for 'examples' param in Client.classify method.

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -165,7 +165,7 @@ class Client:
         self,
         model: str,
         inputs: List[str],
-        examples: List[Example],
+        examples: List[Example] = [],
         taskDescription: str = "",
         outputIndicator: str = ""
     ) -> Classifications:


### PR DESCRIPTION
Intellisense currently raises an error when using the `co.classify` client with finetuned models, where examples aren't (generally) necessary. 

<img width="409" alt="image" src="https://user-images.githubusercontent.com/28828395/166716618-ed528351-2ede-49b7-9356-225afb635b00.png">

Adding default param for `examples` removes the error message.
