### PR TITLE
Use correct method for string representations

### DIFF
--- a/cohere/response.py
+++ b/cohere/response.py
@@ -1,5 +1,5 @@
 class CohereObject():
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         contents = ''
         exclude_list = ['iterator']
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class BinaryDistribution(Distribution):
 
 setuptools.setup(
     name='cohere',
-    version='1.3.7',
+    version='1.3.8',
     author='kipply',
     author_email='carol@cohere.ai',
     description='A Python library for the Cohere API',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -239,6 +239,33 @@ class TestClassify(unittest.TestCase):
         self.assertEqual(prediction.classifications[0].prediction, 'fruit')
         self.assertEqual(prediction.classifications[1].prediction, 'color')
 
+    def test_string_repr(self):
+        prediction = co.classify('medium', ['purple'], [
+            Example('apple', 'fruit'),
+            Example('banana', 'fruit'),
+            Example('cherry', 'fruit'),
+            Example('watermelon', 'fruit'),
+            Example('kiwi', 'fruit'),
+            Example('red', 'color'),
+            Example('blue', 'color'),
+            Example('green', 'color'),
+            Example('yellow', 'color'),
+            Example('magenta', 'color')
+        ])
+        self.assertEqual(repr(prediction), '''cohere.Classifications {
+\tclassifications: [cohere.Classification {
+\tinput: purple
+\tprediction: color
+\tconfidence: [cohere.Confidence {
+\tlabel: fruit
+\tconfidence: 0
+}, cohere.Confidence {
+\tlabel: color
+\tconfidence: 1
+}]
+}]
+}''')
+
 
 class TestTokenize(unittest.TestCase):
     def test_success(self):


### PR DESCRIPTION
This PR fixes the following problem of printing out cohere objects:

**Before:**

```python
print(co.classify(...))
'''
 .cohere.Classifications {
        classifications: [<cohere.classify.Classification object at 0x1056a5bb0>]
}
'''
```
**After:**
```python
print(co.classify(...))
'''
.cohere.Classifications {
        classifications: [cohere.Classification {
        input: purple
        prediction: color
        confidence: [cohere.Confidence {
        label: fruit
        confidence: 0
}, cohere.Confidence {
        label: color
        confidence: 1
}]
}]
}
'''
```