### PR TITLE
Change model param to use body instead of url

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Cohere Endpoint | Function
 /classify | co.classify()
 
 ## Models
-To view an up-to-date list of available models please consult the models section in the [platform](https://os.cohere.ai). To get started try out `large` for Generate, `medium` for Classify or `small` for Embed.
+To view an up-to-date list of available models please consult the models section in the [platform](https://os.cohere.ai). To get started omit `model` from requests to use the default model sizes.
 
 ## Responses
 All of the endpoint functions will return a Cohere object corresponding to the endpoint (e.g. for generation, it would be `Generation`). The responses can be found as instance variables of the object (e.g. generation would be `Generation.text`). The names of these instance variables and a detailed breakdown of the response body can be found in the [Cohere Docs](https://docs.cohere.ai/). Printing the Cohere response object itself will display an organized view of the instance variables.

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -8,18 +8,20 @@ co = cohere.Client(get_api_key())
 
 class TestClassify(unittest.TestCase):
     def test_success(self):
-        prediction = co.classify('medium', ['purple'], [
-            Example('apple', 'fruit'),
-            Example('banana', 'fruit'),
-            Example('cherry', 'fruit'),
-            Example('watermelon', 'fruit'),
-            Example('kiwi', 'fruit'),
-            Example('red', 'color'),
-            Example('blue', 'color'),
-            Example('green', 'color'),
-            Example('yellow', 'color'),
-            Example('magenta', 'color')
-        ])
+        prediction = co.classify(
+            model='medium',
+            inputs=['purple'],
+            examples=[
+                Example('apple', 'fruit'),
+                Example('banana', 'fruit'),
+                Example('cherry', 'fruit'),
+                Example('watermelon', 'fruit'),
+                Example('kiwi', 'fruit'),
+                Example('red', 'color'),
+                Example('blue', 'color'),
+                Example('green', 'color'),
+                Example('yellow', 'color'),
+                Example('magenta', 'color')])
         self.assertIsInstance(prediction.classifications, list)
         self.assertIsInstance(prediction.classifications[0].input, str)
         self.assertIsInstance(prediction.classifications[0].prediction, str)
@@ -33,7 +35,9 @@ class TestClassify(unittest.TestCase):
     def test_empty_inputs(self):
         with self.assertRaises(cohere.CohereError):
             co.classify(
-                'medium', [], [
+                model='medium',
+                inputs=[],
+                examples=[
                     Example('apple', 'fruit'),
                     Example('banana', 'fruit'),
                     Example('cherry', 'fruit'),
@@ -47,35 +51,43 @@ class TestClassify(unittest.TestCase):
                     Example('magenta', 'color')])
 
     def test_success_multi_input(self):
-        prediction = co.classify('medium', ['purple', 'mango'], [
-            Example('apple', 'fruit'),
-            Example('banana', 'fruit'),
-            Example('cherry', 'fruit'),
-            Example('watermelon', 'fruit'),
-            Example('kiwi', 'fruit'),
+        prediction = co.classify(
+            model='medium',
+            inputs=['purple', 'mango'],
+            examples=[
+                Example('apple', 'fruit'),
+                Example('banana', 'fruit'),
+                Example('cherry', 'fruit'),
+                Example('watermelon', 'fruit'),
+                Example('kiwi', 'fruit'),
 
-            Example('red', 'color'),
-            Example('blue', 'color'),
-            Example('green', 'color'),
-            Example('yellow', 'color'),
-            Example('magenta', 'color')])
+                Example('red', 'color'),
+                Example('blue', 'color'),
+                Example('green', 'color'),
+                Example('yellow', 'color'),
+                Example('magenta', 'color')])
         self.assertEqual(prediction.classifications[0].prediction, 'color')
         self.assertEqual(prediction.classifications[1].prediction, 'fruit')
         self.assertEqual(len(prediction.classifications), 2)
 
     def test_success_all_fields(self):
-        prediction = co.classify('medium', ['mango', 'purple'], [
-            Example('apple', 'fruit'),
-            Example('banana', 'fruit'),
-            Example('cherry', 'fruit'),
-            Example('watermelon', 'fruit'),
-            Example('kiwi', 'fruit'),
+        prediction = co.classify(
+            model='medium',
+            inputs=['mango', 'purple'],
+            examples=[
+                Example('apple', 'fruit'),
+                Example('banana', 'fruit'),
+                Example('cherry', 'fruit'),
+                Example('watermelon', 'fruit'),
+                Example('kiwi', 'fruit'),
 
-            Example('red', 'color'),
-            Example('blue', 'color'),
-            Example('green', 'color'),
-            Example('yellow', 'color'),
-            Example('magenta', 'color')
-        ], 'this is a classifier to determine if a word is a fruit of a color', 'This is a')
+                Example('red', 'color'),
+                Example('blue', 'color'),
+                Example('green', 'color'),
+                Example('yellow', 'color'),
+                Example('magenta', 'color')
+            ],
+            taskDescription='this is a classifier to determine if a word is a fruit of a color',
+            outputIndicator='This is a')
         self.assertEqual(prediction.classifications[0].prediction, 'fruit')
         self.assertEqual(prediction.classifications[1].prediction, 'color')

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -40,6 +40,13 @@ class TestEmbed(unittest.TestCase):
         self.assertEqual(len(prediction.embeddings[0]), 1024)
         self.assertEqual(len(prediction.embeddings[1]), 1024)
 
+    def test_default_model(self):
+        prediction = co.embed(
+            texts=['co:here', 'cohere'])
+        self.assertEqual(len(prediction.embeddings), 2)
+        self.assertIsInstance(prediction.embeddings[0], list)
+        self.assertIsInstance(prediction.embeddings[1], list)
+
     def test_success_multiple_batches(self):
         prediction = co.embed(
             model='small',

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -13,7 +13,7 @@ class TestExtract(unittest.TestCase):
             entities=[Entity(type="Name", value="John")])]
         texts = ["hello Roberta, how are you doing today?"]
 
-        extractions = co.unstable_extract('small', examples, texts)
+        extractions = co.unstable_extract(examples, texts)
 
         self.assertIsInstance(extractions, Extractions)
         self.assertIsInstance(extractions[0].text, str)
@@ -24,7 +24,7 @@ class TestExtract(unittest.TestCase):
     def test_empty_text(self):
         with self.assertRaises(cohere.CohereError):
             co.unstable_extract(
-                'small', examples=[Example(
+                examples=[Example(
                     text="hello my name is John, and I like to play ping pong",
                     entities=[Entity(type="Name", value="John")])],
                 texts=[""])
@@ -32,7 +32,7 @@ class TestExtract(unittest.TestCase):
     def test_empty_entities(self):
         with self.assertRaises(cohere.CohereError):
             co.unstable_extract(
-                'large', examples=[Example(
+                examples=[Example(
                     text="hello my name is John, and I like to play ping pong",
                     entities=[])],
                 texts=["hello Roberta, how are you doing today?"])
@@ -56,7 +56,7 @@ class TestExtract(unittest.TestCase):
                 entities=[Entity(type="fruit", value="apple"), Entity(type="color", value="green")])]
         texts = ["Jimmy ate my banana", "my favorite color is yellow", "green apple is my favorite fruit"]
 
-        extractions = co.unstable_extract('medium', examples, texts)
+        extractions = co.unstable_extract(examples, texts)
 
         self.assertIsInstance(extractions, Extractions)
         self.assertIsInstance(extractions[0].text, str)
@@ -89,7 +89,7 @@ class TestExtract(unittest.TestCase):
                 entities=[Entity(type="Name", value="Tina"), Entity(type="Game", value="baseball")])]
         texts = ["hi, my name is Charlie and I like to play basketball", "hello, I'm Olivia and I like to play soccer"]
 
-        extractions = co.unstable_extract('medium', examples, texts)
+        extractions = co.unstable_extract(examples, texts)
 
         self.assertEqual(len(extractions), 2)
         self.assertIsInstance(extractions, Extractions)
@@ -113,7 +113,7 @@ class TestExtract(unittest.TestCase):
                 entities=[Entity(type="Name", value="Tina"), Entity(type="Game", value="baseball")])]
         texts = ["hi, my name is Charlie and I like to play basketball", "hello!"]
 
-        extractions = co.unstable_extract('medium', examples, texts)
+        extractions = co.unstable_extract(examples, texts)
 
         self.assertEqual(len(extractions), 2)
         self.assertIsInstance(extractions, Extractions)

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -7,11 +7,11 @@ co = cohere.Client(get_api_key())
 
 class TestTokenize(unittest.TestCase):
     def test_success(self):
-        tokens = co.tokenize('medium', 'tokenize me!')
+        tokens = co.tokenize('tokenize me!')
         self.assertIsInstance(tokens.tokens, list)
         self.assertIsInstance(tokens.length, int)
         self.assertEqual(tokens.length, len(tokens))
 
     def test_invalid_text(self):
         with self.assertRaises(cohere.CohereError):
-            co.tokenize(model='medium', text='')
+            co.tokenize(text='')


### PR DESCRIPTION
As a part of https://github.com/cohere-ai/blobheart/issues/3963 all endpoints will now take model as an optional param in the body instead of the URL. The old URL model will still be supported but will eventually be deprecated.