### PR TITLE
Update SDK to use updated casing for parameters

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -169,8 +169,8 @@ class Client:
         inputs: List[str],
         model: str = None,
         examples: List[ClassifyExample] = [],
-        taskDescription: str = '',
-        outputIndicator: str = ''
+        task_description: str = '',
+        output_indicator: str = ''
     ) -> Classifications:
         examples_dicts: list[dict[str, str]] = []
         for example in examples:
@@ -181,8 +181,8 @@ class Client:
             'model': model,
             'inputs': inputs,
             'examples': examples_dicts,
-            'taskDescription': taskDescription,
-            'outputIndicator': outputIndicator,
+            'task_description': task_description,
+            'output_indicator': output_indicator,
         })
         response = self.__request(json_body, cohere.CLASSIFY_URL)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class BinaryDistribution(Distribution):
 
 setuptools.setup(
     name='cohere',
-    version='2.0.0',
+    version='2.1.0',
     author='1vn',
     author_email='ivan@cohere.ai',
     description='A Python library for the Cohere API',

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -87,7 +87,7 @@ class TestClassify(unittest.TestCase):
                 Example('yellow', 'color'),
                 Example('magenta', 'color')
             ],
-            taskDescription='this is a classifier to determine if a word is a fruit of a color',
-            outputIndicator='This is a')
+            task_description='this is a classifier to determine if a word is a fruit of a color',
+            output_indicator='This is a')
         self.assertEqual(prediction.classifications[0].prediction, 'fruit')
         self.assertEqual(prediction.classifications[1].prediction, 'color')


### PR DESCRIPTION
the Classify parameters `taskDescription` and `outputIndicator` are being replaced with `task_description` and `output_indicator` respectively to be consistent with the casing of other parameters.

This PR updates the SDK to use these new params.