### PR TITLE
docs: Generation typehint updated to have a list of token likelihoods

### DIFF
--- a/cohere/generation.py
+++ b/cohere/generation.py
@@ -12,7 +12,7 @@ class Generation(CohereObject):
     def __init__(self,
                  text: str,
                  likelihood: float,
-                 token_likelihoods: TokenLikelihood) -> None:
+                 token_likelihoods: List[TokenLikelihood]) -> None:
         self.text = text
         self.likelihood = likelihood
         self.token_likelihoods = token_likelihoods


### PR DESCRIPTION
This is a bit of a nitpick and/or trivial PR: The typehint for `Generation` has been updated from a `Likelihood` to `List[Likelihood]`. I don't think the typehints would be encountered for most users; I came across it when I wanted to mock some `co.generate()` responses in Python for unit test fixtures.