### PR TITLE
print warnings to stderr

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -1,5 +1,6 @@
 import json
 import math
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List
 from urllib.parse import urljoin
@@ -250,7 +251,7 @@ class Client:
 
     def __print_warning_msg(self, response: Response):
         if 'X-API-Warning' in response.headers:
-            print("\033[93mWarning: {}\n\033[0m".format(response.headers['X-API-Warning']))
+            print("\033[93mWarning: {}\n\033[0m".format(response.headers['X-API-Warning']), file=sys.stderr)
 
     def __pyfetch(self, url, headers, json_body) -> Response:
         req = XMLHttpRequest.new()

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='2.2.2',
+                 version='2.2.3',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',


### PR DESCRIPTION
We should print warnings to stderr instead of stdout