### PR TITLE
Add `preset` param

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -90,9 +90,10 @@ class Client:
 
     def generate(
         self,
-        prompt: str,
+        prompt: str = None,
         model: str = None,
-        num_generations: int = 1,
+        preset: str = None,
+        num_generations: int = None,
         max_tokens: int = 20,
         temperature: float = 1.0,
         k: int = 0,
@@ -105,6 +106,7 @@ class Client:
         json_body = json.dumps({
             'model': model,
             'prompt': prompt,
+            'preset': preset,
             'num_generations': num_generations,
             'max_tokens': max_tokens,
             'temperature': temperature,
@@ -162,8 +164,9 @@ class Client:
 
     def classify(
         self,
-        inputs: List[str],
+        inputs: List[str] = [],
         model: str = None,
+        preset: str = None,
         examples: List[ClassifyExample] = [],
         taskDescription: str = '',
         outputIndicator: str = ''
@@ -175,6 +178,7 @@ class Client:
 
         json_body = json.dumps({
             'model': model,
+            'preset': preset,
             'inputs': inputs,
             'examples': examples_dicts,
             'taskDescription': taskDescription,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='2.2.3',
+                 version='2.2.4',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -93,5 +93,5 @@ class TestClassify(unittest.TestCase):
         self.assertEqual(prediction.classifications[1].prediction, 'color')
 
     def test_preset_success(self):
-        prediction = co.classify(preset='PLACEHOLDER-PRESET')
+        prediction = co.classify(preset='SDK-TESTS-PRESET-rfa6h3')
         self.assertIsInstance(prediction.classifications, list)

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -91,3 +91,7 @@ class TestClassify(unittest.TestCase):
             outputIndicator='This is a')
         self.assertEqual(prediction.classifications[0].prediction, 'fruit')
         self.assertEqual(prediction.classifications[1].prediction, 'color')
+
+    def test_preset_success(self):
+        prediction = co.classify(preset='PLACEHOLDER-PRESET')
+        self.assertIsInstance(prediction.classifications, list)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -70,5 +70,5 @@ class TestGenerate(unittest.TestCase):
             _ = cohere.Client('invalid')
 
     def test_preset_success(self):
-        prediction = co.generate(preset='PLACEHOLDER-PRESET')
+        prediction = co.generate(preset='SDK-TESTS-PRESET-cq2r57')
         self.assertIsInstance(prediction.generations[0].text, str)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -68,3 +68,7 @@ class TestGenerate(unittest.TestCase):
     def test_invalid_key(self):
         with self.assertRaises(cohere.CohereError):
             _ = cohere.Client('invalid')
+
+    def test_preset_success(self):
+        prediction = co.generate(preset='PLACEHOLDER-PRESET')
+        self.assertIsInstance(prediction.generations[0].text, str)


### PR DESCRIPTION
Add support for the `preset` param.

The preset param is: The ID of a custom playground preset. You can create presets in the [playground](https://os.cohere.ai/playground). If you use a preset, all other parameters become optional, and any included parameters will override the preset's parameters.
