### PR TITLE
Don't set default value for max_tokens in the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
+## 2.3.0
+* [#92](https://github.com/cohere-ai/cohere-python/pull/92) 
+	* The default value for the `max_tokens` parameter in Generate is now set on the backend
+
+## 2.2.5
+* [#95](https://github.com/cohere-ai/cohere-python/pull/95) 
+    * Introduce Detokenize for converting a list of tokens to a string 
+
 ## 2.2.4
 * [#92](https://github.com/cohere-ai/cohere-python/pull/92) 
     * Handle `truncate` parameter for Classify and Generate
+
 ## 1.3.6 - 2022-05-05
 * [#71](https://github.com/cohere-ai/cohere-python/pull/71) Sunset Choose Best
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.3.0
-* [#92](https://github.com/cohere-ai/cohere-python/pull/92) 
-	* The default value for the `max_tokens` parameter in Generate is now set on the backend
+## 2.5.0
+* [#96](https://github.com/cohere-ai/cohere-python/pull/96)
+    * The default `max_tokens` value is now configured on the backend
+
+## 2.4.2
+* [#102](https://github.com/cohere-ai/cohere-python/pull/102) 
+    * Generate Parameter now accepts `logit_bias` as a parameter
 
 ## 2.2.5
 * [#95](https://github.com/cohere-ai/cohere-python/pull/95) 

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -83,7 +83,7 @@ class Client:
                  prompt: str,
                  model: str = None,
                  num_generations: int = 1,
-                 max_tokens: int = 20,
+                 max_tokens: int = None,
                  temperature: float = 1.0,
                  k: int = 0,
                  p: float = 0.75,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='2.2.5',
+                 version='2.3.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',


### PR DESCRIPTION
Currently if a `max_tokens` value is not specified in calls to `Generate`, the SDK defaults to 20. To make this behavior consistent across all the SDKs and the API, we moved this behavior to the backend.