### PR TITLE
change classify response to use labels field instead of confidences

### DIFF
--- a/cohere/classify.py
+++ b/cohere/classify.py
@@ -1,5 +1,5 @@
 from cohere.response import CohereObject
-from typing import List
+from typing import List, Dict
 
 
 class Confidence(CohereObject):
@@ -8,12 +8,18 @@ class Confidence(CohereObject):
         self.confidence = confidence
 
 
+class LabelPrediction(CohereObject):
+    def __init__(self, confidence: float) -> None:
+        self.confidence = confidence
+
+
 class Classification(CohereObject):
     def __init__(self, input: str,
-                 prediction: str, confidence: Confidence) -> None:
+                 prediction: str, confidence: List[Confidence], labels: Dict[str, LabelPrediction]) -> None:
         self.input = input
         self.prediction = prediction
         self.confidence = confidence
+        self.labels = labels
 
 
 class Classifications(CohereObject):

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -9,7 +9,7 @@ import requests
 from requests import Response
 
 import cohere
-from cohere.classify import Classification, Classifications, Confidence
+from cohere.classify import Classification, Classifications, Confidence, LabelPrediction
 from cohere.classify import Example as ClassifyExample
 from cohere.embeddings import Embeddings
 from cohere.error import CohereError
@@ -181,11 +181,13 @@ class Client:
 
         classifications = []
         for res in response['classifications']:
+            labelObj = {}
             confidenceObj = []
             for i in range(len(res['confidences'])):
                 confidenceObj.append(Confidence(res['confidences'][i]['option'], res['confidences'][i]['confidence']))
-            Classification(res['input'], res['prediction'], confidenceObj)
-            classifications.append(Classification(res['input'], res['prediction'], confidenceObj))
+            for label, prediction in res['labels'].items():
+                labelObj[label] = LabelPrediction(prediction['confidence'])
+            classifications.append(Classification(res['input'], res['prediction'], confidenceObj, labelObj))
 
         return Classifications(classifications)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='2.3.0',
+                 version='2.4.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -29,6 +29,8 @@ class TestClassify(unittest.TestCase):
         self.assertIsInstance(prediction.classifications[0].confidence[0].label, str)
         self.assertIsInstance(prediction.classifications[0].confidence[1].confidence, (int, float))
         self.assertIsInstance(prediction.classifications[0].confidence[1].label, str)
+        self.assertIsInstance(prediction.classifications[0].labels['color'].confidence, (int, float))
+        self.assertEqual(len(prediction.classifications[0].labels), 2)
         self.assertEqual(len(prediction.classifications), 1)
         self.assertEqual(prediction.classifications[0].prediction, 'color')
 


### PR DESCRIPTION
Classify endpoint now returns a map of labels to their confidences. The old confidences array is being deprecated so it should get removed from the SDK.

Tests will pass once classify changes are deployed.