### PR TITLE
add token_strings to tokenize

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -236,7 +236,7 @@ class Client:
             'text': text,
         })
         response = self.__request(json_body, cohere.TOKENIZE_URL)
-        return Tokens(response['tokens'])
+        return Tokens(response['tokens'], response['token_strings'])
 
     def detokenize(self, tokens: List[int]) -> Detokenization:
         json_body = json.dumps({

--- a/cohere/tokenize.py
+++ b/cohere/tokenize.py
@@ -3,8 +3,9 @@ from typing import List
 
 
 class Tokens(CohereObject):
-    def __init__(self, tokens: List[int]) -> None:
+    def __init__(self, tokens: List[int], token_strings: List[str]) -> None:
         self.tokens = tokens
+        self.token_strings = token_strings
         self.iterator = iter(tokens)
         self.length = len(tokens)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='2.4.0',
+                 version='2.4.1',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -9,8 +9,10 @@ class TestTokenize(unittest.TestCase):
     def test_success(self):
         tokens = co.tokenize('tokenize me!')
         self.assertIsInstance(tokens.tokens, list)
+        self.assertIsInstance(tokens.token_strings, list)
         self.assertIsInstance(tokens.length, int)
-        self.assertEqual(tokens.length, len(tokens))
+        self.assertEqual(tokens.length, len(tokens.tokens))
+        self.assertEqual(tokens.length, len(tokens.token_strings))
 
     def test_invalid_text(self):
         with self.assertRaises(cohere.CohereError):


### PR DESCRIPTION
The tokenize endpoint now contains token_strings field with each token's string representation. 