### PR TITLE
Fix python version errors in Lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9.13
+          python-version: 3.9
           architecture: x64
       - name: Checkout the code
         uses: actions/checkout@v3


### PR DESCRIPTION
The Lint workflow has been failing due to an outdated version of Python specified in CI. Instead of setting version `3.9.13`, we can loosen the restriction to `3.9`