### PR TITLE
Add support for prompt_vars

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -89,6 +89,7 @@ class Client:
 
     def generate(self,
                  prompt: str = None,
+                 prompt_vars: object = {},
                  model: str = None,
                  preset: str = None,
                  num_generations: int = 1,
@@ -105,6 +106,7 @@ class Client:
         json_body = json.dumps({
             'model': model,
             'prompt': prompt,
+            'prompt_vars': prompt_vars,
             'preset': preset,
             'num_generations': num_generations,
             'max_tokens': max_tokens,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='2.7.0',
+                 version='2.8.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -65,3 +65,7 @@ class TestGenerate(unittest.TestCase):
         self.assertIsInstance(prediction.generations[0].text, str)
         self.assertIsNone(prediction.generations[0].token_likelihoods)
         self.assertEqual(prediction.return_likelihoods, 'NONE')
+
+    def test_prompt_vars(self):
+        prediction = co.generate(prompt='Hello {{ name }}', prompt_vars={'name': 'Aidan'})
+        self.assertIsInstance(prediction.generations[0].text, str)


### PR DESCRIPTION
Add support for the `prompt_vars` argument, allowing you to provide variable for liquid templates inside of prompts!