### PR TITLE
Support for Token Streaming

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
           python-version: "3.6"
       - env:
           CO_API_KEY: ${{ secrets.CO_API_PROD_KEY }}
-        run: pip install requests && python -m unittest discover tests
+        run: pip install requests, sseclient-py && python -m unittest discover tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
           python-version: "3.6"
       - env:
           CO_API_KEY: ${{ secrets.CO_API_PROD_KEY }}
-        run: pip install requests, sseclient-py && python -m unittest discover tests
+        run: pip install requests sseclient-py && python -m unittest discover tests

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -102,7 +102,8 @@ class Client:
                  return_likelihoods: str = 'NONE',
                  truncate: str = None,
                  logit_bias: Dict[int, float] = {},
-                 stream: bool = False) -> Union[Generations, GenerationStream]:
+                 stream: bool = False,
+                 chunk_size: int = 1) -> Union[Generations, GenerationStream]:
         json_body = {
             'model': model,
             'prompt': prompt,
@@ -119,7 +120,8 @@ class Client:
             'return_likelihoods': return_likelihoods,
             'truncate': truncate,
             'logit_bias': logit_bias,
-            'stream': stream
+            'stream': stream,
+            'chunk_size': chunk_size
         }
         response = self._executor.submit(self.__request, cohere.GENERATE_URL, json=json_body)
         if stream:

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -1,10 +1,10 @@
 import json
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, Generator, List, Union
+from typing import Any, Dict, List, Union
 from urllib.parse import urljoin
 
-import requests, sseclient
+import requests
 from requests import Response
 
 import cohere
@@ -17,7 +17,7 @@ from cohere.error import CohereError
 from cohere.extract import Entity
 from cohere.extract import Example as ExtractExample
 from cohere.extract import Extraction, Extractions
-from cohere.generation import GenerationStream, Generations, Generation
+from cohere.generation import GenerationStream, Generations
 from cohere.tokenize import Tokens
 
 use_xhr_client = False
@@ -126,7 +126,7 @@ class Client:
             return Generations(return_likelihoods=return_likelihoods, _future=response)
         else:
             return GenerationStream(return_likelihoods=return_likelihoods, _future=response)
-            
+
     def embed(self, texts: List[str], model: str = None, truncate: str = 'NONE') -> Embeddings:
         responses = []
         json_bodys = []
@@ -267,5 +267,4 @@ class Client:
             if 'message' in res:  # has errors
                 raise CohereError(message=res['message'], http_status=response.status_code, headers=response.headers)
             self.__print_warning_msg(response)
-
         return res

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, Generator, List
+from typing import Any, Dict, Generator, List, Union
 from urllib.parse import urljoin
 
 import requests, sseclient
@@ -102,7 +102,7 @@ class Client:
                  return_likelihoods: str = 'NONE',
                  truncate: str = None,
                  logit_bias: Dict[int, float] = {},
-                 stream: bool = False) -> Generations | GenerationStream:
+                 stream: bool = False) -> Union[Generations, GenerationStream]:
         json_body = {
             'model': model,
             'prompt': prompt,

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -102,7 +102,7 @@ class Client:
                  return_likelihoods: str = 'NONE',
                  truncate: str = None,
                  logit_bias: Dict[int, float] = {},
-                 stream: bool = False) -> Generations | Generator[Generations, None, None]:
+                 stream: bool = False) -> Generations | GenerationStream:
         json_body = {
             'model': model,
             'prompt': prompt,
@@ -126,13 +126,6 @@ class Client:
             return Generations(return_likelihoods=return_likelihoods, _future=response)
         else:
             return GenerationStream(return_likelihoods=return_likelihoods, _future=response)
-            # client = sseclient.SSEClient(response.result())
-            # for event in client.events():
-            #     gen = json.loads(event.data)
-            #     likelihood = None
-            #     if 'likelihood' in gen.keys():
-            #         likelihood = gen['likelihood']
-            #     yield Generation(gen["text"], likelihood, None)
             
     def embed(self, texts: List[str], model: str = None, truncate: str = 'NONE') -> Embeddings:
         responses = []

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -252,7 +252,7 @@ class Client:
             headers['Cohere-Version'] = self.cohere_version
 
         url = urljoin(self.api_url, endpoint)
-        if json["stream"]:
+        if 'stream' in json.keys() and json['stream']:
             headers.update({
                 'Content-Type': 'text/event-stream',
                 'Connection': 'keep-alive',

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -122,10 +122,10 @@ class Client:
             'stream': stream
         }
         response = self._executor.submit(self.__request, cohere.GENERATE_URL, json=json_body)
-        if not stream:
-            return Generations(return_likelihoods=return_likelihoods, _future=response)
-        else:
+        if stream:
             return GenerationStream(return_likelihoods=return_likelihoods, _future=response)
+        else:
+            return Generations(return_likelihoods=return_likelihoods, _future=response)
 
     def embed(self, texts: List[str], model: str = None, truncate: str = 'NONE') -> Embeddings:
         responses = []
@@ -246,12 +246,10 @@ class Client:
 
         url = urljoin(self.api_url, endpoint)
         if 'stream' in json.keys() and json['stream']:
-            print("use stream")
             headers.update({
                 'Content-Type': 'text/event-stream',
                 'Connection': 'keep-alive',
                 'Accept': 'text/event-stream'})
-            url = "http://localhost:8050/shrimpftt/generate"
             response = requests.post(url, headers=headers, json=json, stream=True)
             return response
         elif use_xhr_client:

--- a/cohere/generation.py
+++ b/cohere/generation.py
@@ -1,4 +1,5 @@
-import sseclient, json
+import sseclient
+import json
 from concurrent.futures import Future
 from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Union
 
@@ -70,13 +71,14 @@ class Generations(CohereObject):
     def __getitem__(self, index) -> Generation:
         return self.generations[index]
 
+
 class GenerationStream(CohereObject):
 
     def __init__(self,
-                return_likelihoods: str,
-                response: Optional[Dict[str, Any]] = None,
-                *,
-                _future: Optional[Future] = None) -> None:
+                 return_likelihoods: str,
+                 response: Optional[Dict[str, Any]] = None,
+                 *,
+                 _future: Optional[Future] = None) -> None:
         self.return_likelihoods = return_likelihoods
         self.client = None
         if _future is not None:
@@ -84,7 +86,7 @@ class GenerationStream(CohereObject):
         else:
             assert response is not None
             self.client = sseclient.SSEClient(response)
-    
+
     def stream(self):
         for event in self.client.events():
             gen = json.loads(event.data)

--- a/cohere/generation.py
+++ b/cohere/generation.py
@@ -79,6 +79,7 @@ class GenerationStream(CohereObject):
                  response: Optional[Dict[str, Any]] = None,
                  *,
                  _future: Optional[Future] = None) -> None:
+        self.curr_generation = None
         self.return_likelihoods = return_likelihoods
         self.client = None
         if _future is not None:
@@ -93,4 +94,8 @@ class GenerationStream(CohereObject):
             likelihood = None
             if self.return_likelihoods in ['GENERATION', 'ALL'] and 'likelihood' in gen.keys():
                 likelihood = gen['likelihood']
-            yield Generation(gen["text"], likelihood, None)
+            self.curr_generation = Generation(gen["text"], likelihood, None)
+            yield self.curr_generation
+
+    def response(self):
+        return self.curr_generation

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(name='cohere',
                  long_description_content_type='text/markdown',
                  url='https://github.com/cohere-ai/cohere-python',
                  packages=setuptools.find_packages(),
-                 install_requires=['requests'],
+                 install_requires=['requests', 'sseclient-py'],
                  include_package_data=True,
                  classifiers=[
                      'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(name='cohere',
                  long_description_content_type='text/markdown',
                  url='https://github.com/cohere-ai/cohere-python',
                  packages=setuptools.find_packages(),
-                 install_requires=['requests', 'sseclient-py'],
+                 install_requires=['requests'],
                  include_package_data=True,
                  classifiers=[
                      'Programming Language :: Python :: 3',


### PR DESCRIPTION
Add token streaming support for python sdk, add `stream` and `chunk_size` optional params to `co.generate()`

**Sample use case**
```
import cohere
import os

co = cohere.Client(os.environ["CO_API_KEY"])

response_generator = co.generate("Today I went to the park", stream=True)

for gen in response_generator.stream():
   # do something with gen

final_response = response_generator.response()
```
