### PR TITLE
Bump python version in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,10 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.9
-          architecture: x64
+        uses: actions/setup-python@v4
       - name: Checkout the code
         uses: actions/checkout@v3
       - name: Install flake8

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.6"
+      - uses: actions/setup-python@v4
       - env:
           CO_API_KEY: ${{ secrets.CO_API_PROD_KEY }}
         run: pip install requests && python -m unittest discover tests


### PR DESCRIPTION
Github Actions are failing in the repo because one of the workflows uses python 3.6 which is no longer supported by the `setup-python` github action. 

This PR:

- updates all workflows to use the latest setup-python action
- removes explicitly specifying python version, to avoid having to keep bumping it as they drop support.