### PR TITLE
Remove "confidence" field from language detection API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 3.1.2
+# 3.1.3
 
 - [#129](https://github.com/cohere-ai/cohere-python/pull/129)
   - Add support for `end_sequences` param in Generate API

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -194,7 +194,7 @@ class Client:
         response = self.__request(cohere.DETECT_LANG_URL, json=json_body)
         results = []
         for result in response["results"]:
-            results.append(Language(result["language_code"], result["language_name"], result["confidence"]))
+            results.append(Language(result["language_code"], result["language_name"]))
         return DetectLanguageResponse(results)
 
     def __print_warning_msg(self, response: Response):

--- a/cohere/detectlang.py
+++ b/cohere/detectlang.py
@@ -4,16 +4,12 @@ from typing import List
 
 class Language(CohereObject):
 
-    def __init__(self, code: str, name: str, confidence: float):
+    def __init__(self, code: str, name: str):
         self.language_code = code
         self.language_name = name
-        self.confidence = confidence
 
     def __repr__(self) -> str:
-        return (
-            f"Language<language_code: \"{self.language_code}\", "
-            f"language_name: \"{self.language_name}\", confidence: {self.confidence}>"
-        )
+        return f"Language<language_code: \"{self.language_code}\", language_name: \"{self.language_name}\">"
 
 
 class DetectLanguageResponse:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.1.2',
+                 version='3.1.3',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',


### PR DESCRIPTION
The confidence field has been showing some non-obvious results, so we are removing it.