### PR TITLE
fix: tests broken due to deprecated model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.1.5',
+                 version='3.1.6',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -9,7 +9,7 @@ co = cohere.Client(get_api_key())
 class TestClassify(unittest.TestCase):
 
     def test_success(self):
-        prediction = co.classify(model='medium',
+        prediction = co.classify(model='small',
                                  inputs=['purple'],
                                  examples=[
                                      Example('apple', 'fruit'),
@@ -34,7 +34,7 @@ class TestClassify(unittest.TestCase):
 
     def test_empty_inputs(self):
         with self.assertRaises(cohere.CohereError):
-            co.classify(model='medium',
+            co.classify(model='small',
                         inputs=[],
                         examples=[
                             Example('apple', 'fruit'),
@@ -50,7 +50,7 @@ class TestClassify(unittest.TestCase):
                         ])
 
     def test_success_multi_input(self):
-        prediction = co.classify(model='medium',
+        prediction = co.classify(model='small',
                                  inputs=['purple', 'mango'],
                                  examples=[
                                      Example('apple', 'fruit'),
@@ -69,7 +69,7 @@ class TestClassify(unittest.TestCase):
         self.assertEqual(len(prediction.classifications), 2)
 
     def test_success_all_fields(self):
-        prediction = co.classify(model='medium',
+        prediction = co.classify(model='small',
                                  inputs=['mango', 'purple'],
                                  examples=[
                                      Example('apple', 'fruit'),

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -12,6 +12,6 @@ co = cohere.Client(API_KEY)
 class TestFeedback(unittest.TestCase):
 
     def test_success(self):
-        generations = co.generate(model='small', prompt='co:here', max_tokens=1)
+        generations = co.generate(model='medium', prompt='co:here', max_tokens=1)
         feedback = generations[0].feedback("this is a test", accepted=True)
         self.assertIsInstance(feedback, Feedback)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -11,28 +11,28 @@ co = cohere.Client(API_KEY)
 class TestGenerate(unittest.TestCase):
 
     def test_success(self):
-        prediction = co.generate(model='small', prompt='co:here', max_tokens=1)
+        prediction = co.generate(model='medium', prompt='co:here', max_tokens=1)
         self.assertIsInstance(prediction.generations[0].text, str)
         self.assertIsNone(prediction.generations[0].token_likelihoods)
         self.assertEqual(prediction.return_likelihoods, None)
 
     def test_success_batched(self):
         _batch_size = 10
-        predictions = co.batch_generate(model='small', prompts=['co:here'] * _batch_size, max_tokens=1)
+        predictions = co.batch_generate(model='medium', prompts=['co:here'] * _batch_size, max_tokens=1)
         for prediction in predictions:
             self.assertIsInstance(prediction.generations[0].text, str)
             self.assertIsNone(prediction.generations[0].token_likelihoods)
             self.assertEqual(prediction.return_likelihoods, None)
 
     def test_return_likelihoods_generation(self):
-        prediction = co.generate(model='small', prompt='co:here', max_tokens=1, return_likelihoods='GENERATION')
+        prediction = co.generate(model='medium', prompt='co:here', max_tokens=1, return_likelihoods='GENERATION')
         self.assertTrue(prediction.generations[0].token_likelihoods)
         self.assertTrue(prediction.generations[0].token_likelihoods[0].token)
         self.assertIsNotNone(prediction.generations[0].likelihood)
         self.assertEqual(prediction.return_likelihoods, 'GENERATION')
 
     def test_return_likelihoods_all(self):
-        prediction = co.generate(model='small', prompt='hi', max_tokens=1, return_likelihoods='ALL')
+        prediction = co.generate(model='medium', prompt='hi', max_tokens=1, return_likelihoods='ALL')
         self.assertEqual(len(prediction.generations[0].token_likelihoods), 2)
         self.assertIsNotNone(prediction.generations[0].likelihood)
         self.assertEqual(prediction.return_likelihoods, 'ALL')
@@ -46,22 +46,22 @@ class TestGenerate(unittest.TestCase):
             co.generate(model='this-better-not-exist', prompt='co:here', max_tokens=1).generations
 
     def test_no_version_works(self):
-        cohere.Client(API_KEY).generate(model='small', prompt='co:here', max_tokens=1).generations
+        cohere.Client(API_KEY).generate(model='medium', prompt='co:here', max_tokens=1).generations
 
     def test_invalid_version_fails(self):
         with self.assertRaises(cohere.CohereError):
-            _ = cohere.Client(API_KEY, 'fake').generate(model='small', prompt='co:here', max_tokens=1).generations
+            _ = cohere.Client(API_KEY, 'fake').generate(model='medium', prompt='co:here', max_tokens=1).generations
 
     def test_invalid_key(self):
         with self.assertRaises(cohere.CohereError):
             _ = cohere.Client('invalid')
 
     def test_preset_success(self):
-        prediction = co.generate(preset='SDK-TESTS-PRESET-cq2r57')
+        prediction = co.generate(preset='SDK-PRESET-TEST-t94jfm')
         self.assertIsInstance(prediction.generations[0].text, str)
 
     def test_logit_bias(self):
-        prediction = co.generate(model='small', prompt='co:here', logit_bias={11: -5.5}, max_tokens=1)
+        prediction = co.generate(model='medium', prompt='co:here', logit_bias={11: -5.5}, max_tokens=1)
         self.assertIsInstance(prediction.generations[0].text, str)
         self.assertIsNone(prediction.generations[0].token_likelihoods)
         self.assertEqual(prediction.return_likelihoods, None)


### PR DESCRIPTION
`small` is no longer available on generate
`medium` is no longer available on classify
preset had to be changed since it was using `small` on generate 