### PR TITLE
Add a retry policy for failed requests

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 
 import requests
 from requests import Response
+from requests.adapters import HTTPAdapter, Retry
 
 import cohere
 from cohere.chat import Chat
@@ -36,7 +37,8 @@ class Client:
                  num_workers: int = 64,
                  request_dict: dict = {},
                  check_api_key: bool = True,
-                 client_name: str = None) -> None:
+                 client_name: str = None,
+                 max_retries: int = 3) -> None:
         """
         Initialize the client.
         Args:
@@ -54,6 +56,7 @@ class Client:
         self.num_workers = num_workers
         self.request_dict = request_dict
         self.request_source = 'python-sdk'
+        self.max_retries = max_retries
         if client_name:
             self.request_source += ":" + client_name
 
@@ -266,7 +269,17 @@ class Client:
             self.__print_warning_msg(response)
             return response
         else:
-            response = requests.request('POST', url, headers=headers, json=json, **self.request_dict)
+            session = requests.Session()
+            retries = Retry(
+                total=self.max_retries,
+                backoff_factor=0.5,
+                allowed_methods=['POST', 'GET'],
+                status_forcelist=[429, 500, 502, 503, 504]
+            )
+            session.mount('https://', HTTPAdapter(max_retries=retries))
+            session.mount('http://', HTTPAdapter(max_retries=retries))
+
+            response = session.request('POST', url, headers=headers, json=json, **self.request_dict)
             try:
                 res = response.json()
             except Exception:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.1.6',
+                 version='3.1.7',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',


### PR DESCRIPTION
Large embed requests were failing due to transient errors during batching, which would fail the entire request. The retry policy should prevent the entire batch of requests from failing due to a single error.