### PR TITLE
Update embed batch size

### DIFF
--- a/cohere/__init__.py
+++ b/cohere/__init__.py
@@ -3,7 +3,7 @@ from .error import CohereError
 
 COHERE_API_URL = 'https://api.cohere.ai'
 COHERE_VERSION = '2022-12-06'
-COHERE_EMBED_BATCH_SIZE = 16
+COHERE_EMBED_BATCH_SIZE = 96
 CHAT_URL = 'chat'
 CLASSIFY_URL = 'classify'
 DETECT_LANG_URL = 'detect-language'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.2.0',
+                 version='3.2.1',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',


### PR DESCRIPTION
The embed API supports up to 96 texts to be passed in. Updating the SDK to use that batch size too.