### PR TITLE
Add support for "abstractiveness" param in co.summarize 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,85 +1,81 @@
 # Changelog
 
-# 3.2.0
+# 3.3
+
+- [#146](https://github.com/cohere-ai/cohere-python/pull/146)
+  - Add new experimental `co.rerank` api 
+- [#150](https://github.com/cohere-ai/cohere-python/pull/150)
+  - Add `abstractiveness` param for co.summarize
+ 
+# 3.2
+
 - [#138](https://github.com/cohere-ai/cohere-python/pull/138)
   - Add `model` to the chat endpoint's parameters
+- [#145](https://github.com/cohere-ai/cohere-python/pull/145)
+  - Add new experimental `co.summarize` API
 
-# 3.1.3
+# 3.1
 
 - [#129](https://github.com/cohere-ai/cohere-python/pull/129)
   - Add support for `end_sequences` param in Generate API
 
-# 3.1.0
+# 3.1
 
 - [#126](https://github.com/cohere-ai/cohere-python/pull/126)
   - Add new `co.detect_language` api
 
-# 3.0.1
+# 3.0
 
 - [#125](https://github.com/cohere-ai/cohere-python/pull/123)
   - Improve the Classify response string representation
 
-# 3.0.0
-
-- [#125](https://github.com/cohere-ai/cohere-python/pull/125)
-  - Remove the deprecated "confidences" field from the classify response
-
-## 2.9.0
+## 2.9
 
 - [#120](https://github.com/cohere-ai/cohere-python/pull/120)
   - Remove experimental Extract API from the SDK
 
-## 2.8.0
+## 2.8
 
 - [#112](https://github.com/cohere-ai/cohere-python/pull/112)
   - Add support for `prompt_vars` parameter for co.Generate
 
-## 2.7.0
+## 2.7
 
 - [#110](https://github.com/cohere-ai/cohere-python/pull/110)
   - Classification.confidence is now a float instead of a list
 
-## 2.6.1
+## 2.6
 
 - [#105](https://github.com/cohere-ai/cohere-python/pull/105)
   - Remove deprecated options from classify
-
-## 2.6.0
-
 - [#104](https://github.com/cohere-ai/cohere-python/pull/104)
   - Remove experimental `moderate` api
 
-## 2.5.0
+## 2.5
 
 - [#96](https://github.com/cohere-ai/cohere-python/pull/96)
   - The default `max_tokens` value is now configured on the backend
 
-## 2.4.2
+## 2.4
 
 - [#102](https://github.com/cohere-ai/cohere-python/pull/102)
   - Generate Parameter now accepts `logit_bias` as a parameter
 
-## 2.2.5
+## 2.2
 
 - [#95](https://github.com/cohere-ai/cohere-python/pull/95)
   - Introduce Detokenize for converting a list of tokens to a string
-
-## 2.2.4
-
 - [#92](https://github.com/cohere-ai/cohere-python/pull/92)
   - Handle `truncate` parameter for Classify and Generate
 
-## 1.3.6 - 2022-05-05
+## 1.3
 
 - [#71](https://github.com/cohere-ai/cohere-python/pull/71) Sunset Choose Best
 
-## 1.0.2 - 2021-11-30
+## 1.0
 
 - [#38](https://github.com/cohere-ai/cohere-python/pull/38)
   - Handle `truncate` parameter for Embed
-
-## 1.0.1 - 2021-11-17
-
 - [#36](https://github.com/cohere-ai/cohere-python/pull/36)
   Change generations to return `Generations`, which has as a list of `Generation` \* Each `Generation` has a `text` and `token_likelihoods` field to store generations and token likelihoods respectively
 - [#34](https://github.com/cohere-ai/cohere-python/pull/34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [#146](https://github.com/cohere-ai/cohere-python/pull/146)
   - Add new experimental `co.rerank` api 
 - [#150](https://github.com/cohere-ai/cohere-python/pull/150)
-  - Add `abstractiveness` param for co.summarize
+  - Add `abstractiveness` param for `co.summarize`
  
 # 3.2
 

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -221,7 +221,7 @@ class Client:
             abstractiveness (str) One of {"high", "medium", "low"}, defaults to "high". \
                 Controls how close to the original text the summary is. "Low" abstractiveness \
                 summaries will lean towards reusing sentences verbatim, while "high" abstractiveness \
-                summaries will tend to paraphrase more. 
+                summaries will tend to paraphrase more.
             temperature (float): Ranges from 0 to 5. Controls the randomness of the output. \
                 Lower values tend to generate more “predictable” output, while higher values \
                 tend to generate more “creative” output. The sweet spot is typically between 0 and 1.

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -208,7 +208,7 @@ class Client:
         return Classifications(classifications)
 
     def summarize(self, text: str, model: str = None, length: str = None, format: str = None, temperature: float = None,
-                  additional_instruction: str = None) -> SummarizeResponse:
+                  additional_instruction: str = None, abstractiveness: str = None) -> SummarizeResponse:
         """Return a generated summary of the specified length for the provided text.
 
         Args:
@@ -218,6 +218,10 @@ class Client:
                 Controls the length of the summary.
             format (str): (Optional) One of {"paragraph", "bullets"}, defaults to "bullets". \
                 Controls the format of the summary.
+            abstractiveness (str) One of {"high", "medium", "low"}, defaults to "high". \
+                Controls how close to the original text the summary is. "Low" abstractiveness \
+                summaries will lean towards reusing sentences verbatim, while "high" abstractiveness \
+                summaries will tend to paraphrase more. 
             temperature (float): Ranges from 0 to 5. Controls the randomness of the output. \
                 Lower values tend to generate more “predictable” output, while higher values \
                 tend to generate more “creative” output. The sweet spot is typically between 0 and 1.

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -253,6 +253,7 @@ class Client:
             'format': format,
             'temperature': temperature,
             'additional_instruction': additional_instruction,
+            'abstractiveness': abstractiveness
         }
         # remove None values from the dict
         json_body = {k: v for k, v in json_body.items() if v is not None}

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -253,7 +253,7 @@ class Client:
             'format': format,
             'temperature': temperature,
             'additional_instruction': additional_instruction,
-            'abstractiveness': abstractiveness
+            'abstractiveness': abstractiveness,
         }
         # remove None values from the dict
         json_body = {k: v for k, v in json_body.items() if v is not None}

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.3.1',
+                 version='3.3.2',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',


### PR DESCRIPTION
Introduces the `abstractiveness` param for `co.summarize`. `Abstractiveness` can be set to "low", "medium", "high", and it control how close to the original text the summary is. "Low" abstractiveness summaries will lean towards reusing sentences verbatim, while "high" abstractiveness summaries will tend to paraphrase more. 


This PR also modifies the changelog to stop indicating patch versions.