### PR TITLE
Co.chat - add return chatlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 3.4
+- [#154](https://github.com/cohere-ai/cohere-python/pull/154)
+  - Add support for `return_chatlog` parameter for co.Chat
+
 # 3.3
 
 - [#146](https://github.com/cohere-ai/cohere-python/pull/146)

--- a/cohere/chat.py
+++ b/cohere/chat.py
@@ -8,6 +8,7 @@ class Chat(CohereObject):
     def __init__(self,
                  query: str,
                  persona: str,
+                 return_chatlog: bool = False,
                  response: Optional[Dict[str, Any]] = None,
                  *,
                  _future: Optional[Future] = None,
@@ -17,13 +18,19 @@ class Chat(CohereObject):
         self.persona = persona
 
         if _future is not None:
-            self._init_from_future(_future)
+            self._init_from_future(_future, return_chatlog)
         else:
             assert response is not None
             self.reply = self._reply(response)
             self.session_id = self._session_id(response)
 
-    def _init_from_future(self, future: Future):
+            if return_chatlog:
+                self.chatlog = self._chatlog
+
+    def _init_from_future(self, future: Future, return_chatlog: bool):
+        if return_chatlog:
+            self.chatlog = AsyncAttribute(future, self._chatlog)
+
         self.reply = AsyncAttribute(future, self._reply)
         self.session_id = AsyncAttribute(future, self._session_id)
 
@@ -32,6 +39,9 @@ class Chat(CohereObject):
 
     def _session_id(self, response: Dict[str, Any]) -> str:
         return response['session_id']
+
+    def _chatlog(self, response: Dict[str, Any]) -> str:
+        return response['chatlog']
 
     def respond(self, response: str) -> "Chat":
         return self.client.chat(query=response, session_id=self.session_id, persona=self.persona)

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -151,6 +151,34 @@ class Client:
              persona: str = "cohere",
              model: str = None,
              return_chatlog: bool = False) -> Chat:
+        """Returns a Chat object with the query reply.
+
+        Args:
+            query (str): The query to send to the chatbot.
+            session_id (str): (Optional) The session id to continue the conversation.
+            persona (str): (Optional) The persona to use.
+            model (str): (Optional) The model to use for generating the next reply.
+            return_chatlog (bool): (Optional) Whether to return the chatlog.
+
+        Example:
+        ```
+        res = co.chat(query="Hey! How are you doing today?")
+        print(res.reply)
+        print(res.session_id)
+        ```
+
+        Example:
+        ```
+        res = co.chat(
+            query="Hey! How are you doing today?",
+            session_id="1234",
+            persona="fortune",
+            model="command-xlarge",
+            return_chatlog=True)
+        print(res.reply)
+        print(res.chatlog)
+        ```
+        """
         json_body = {
             'query': query,
             'session_id': session_id,

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -145,12 +145,13 @@ class Client:
         response = self._executor.submit(self.__request, cohere.GENERATE_URL, json=json_body)
         return Generations(return_likelihoods=return_likelihoods, _future=response, client=self)
 
-    def chat(self, query: str, session_id: str = "", persona: str = "cohere", model: str = None) -> Chat:
+    def chat(self, query: str, session_id: str = "", persona: str = "cohere", model: str = None, return_chatlog: bool = None) -> Chat:
         json_body = {
             'query': query,
             'session_id': session_id,
             'persona': persona,
             'model': model,
+            'return_chatlog': return_chatlog,
         }
         response = self._executor.submit(self.__request, cohere.CHAT_URL, json=json_body)
         return Chat(query=query, persona=persona, _future=response, client=self)

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -145,7 +145,12 @@ class Client:
         response = self._executor.submit(self.__request, cohere.GENERATE_URL, json=json_body)
         return Generations(return_likelihoods=return_likelihoods, _future=response, client=self)
 
-    def chat(self, query: str, session_id: str = "", persona: str = "cohere", model: str = None, return_chatlog: bool = None) -> Chat:
+    def chat(self,
+             query: str,
+             session_id: str = "",
+             persona: str = "cohere",
+             model: str = None,
+             return_chatlog: bool = False) -> Chat:
         json_body = {
             'query': query,
             'session_id': session_id,
@@ -154,7 +159,7 @@ class Client:
             'return_chatlog': return_chatlog,
         }
         response = self._executor.submit(self.__request, cohere.CHAT_URL, json=json_body)
-        return Chat(query=query, persona=persona, _future=response, client=self)
+        return Chat(query=query, persona=persona, _future=response, client=self, return_chatlog=return_chatlog)
 
     def embed(self, texts: List[str], model: str = None, truncate: str = None) -> Embeddings:
         responses = []

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.3.4',
+                 version='3.4.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -65,9 +65,12 @@ class TestChat(unittest.TestCase):
         self.assertIsInstance(prediction.reply, str)
         self.assertIsInstance(prediction.session_id, str)
         self.assertIsNotNone(prediction.chatlog)
-    
+        self.assertGreaterEqual(len(prediction.chatlog), len(prediction.reply))
+
     def test_return_chatlog_false(self):
         prediction = co.chat("Yo what up?", return_chatlog=False)
         self.assertIsInstance(prediction.reply, str)
         self.assertIsInstance(prediction.session_id, str)
-        self.assertIsNone(prediction.chatlog)
+
+        with self.assertRaises(AttributeError):
+            prediction.chatlog

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -59,3 +59,15 @@ class TestChat(unittest.TestCase):
     def test_invalid_model(self):
         with self.assertRaises(cohere.CohereError):
             co.chat("Yo what up?", model="NOT_A_VALID_MODEL").reply
+
+    def test_return_chatlog(self):
+        prediction = co.chat("Yo what up?", return_chatlog=True)
+        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.session_id, str)
+        self.assertIsNotNone(prediction.chatlog)
+    
+    def test_return_chatlog_false(self):
+        prediction = co.chat("Yo what up?", return_chatlog=False)
+        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.session_id, str)
+        self.assertIsNone(prediction.chatlog)


### PR DESCRIPTION
## What this PR does

- Adds `return_chatlog` as an option param to co.chat
- Returns the chatlog if `return_chatlog` is set to true
- Adds unit tests for the new functionality
- Closes CNV-288

## How it was tested
- Unit tests