### PR TITLE
Co.chat - add return prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 # 3.5
-- 
- - Add support for `return_prompt` parameter for co.Chat
+- [#155](https://github.com/cohere-ai/cohere-python/pull/155)
+  - Add support for `return_prompt` parameter for co.Chat
 
 # 3.4
 - [#154](https://github.com/cohere-ai/cohere-python/pull/154)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 3.5
+- 
+ - Add support for `return_prompt` parameter for co.Chat
+
 # 3.4
 - [#154](https://github.com/cohere-ai/cohere-python/pull/154)
   - Add support for `return_chatlog` parameter for co.Chat

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -150,7 +150,8 @@ class Client:
              session_id: str = "",
              persona: str = "cohere",
              model: str = None,
-             return_chatlog: bool = False) -> Chat:
+             return_chatlog: bool = False,
+             return_prompt: bool = False) -> Chat:
         """Returns a Chat object with the query reply.
 
         Args:
@@ -159,6 +160,7 @@ class Client:
             persona (str): (Optional) The persona to use.
             model (str): (Optional) The model to use for generating the next reply.
             return_chatlog (bool): (Optional) Whether to return the chatlog.
+            return_prompt (bool): (Optional) Whether to return the prompt.
 
         Example:
         ```
@@ -174,9 +176,11 @@ class Client:
             session_id="1234",
             persona="fortune",
             model="command-xlarge",
-            return_chatlog=True)
+            return_chatlog=True,
+            return_prompt=True,)
         print(res.reply)
         print(res.chatlog)
+        print(res.prompt)
         ```
         """
         json_body = {
@@ -185,9 +189,17 @@ class Client:
             'persona': persona,
             'model': model,
             'return_chatlog': return_chatlog,
+            'return_prompt': return_prompt,
         }
         response = self._executor.submit(self.__request, cohere.CHAT_URL, json=json_body)
-        return Chat(query=query, persona=persona, _future=response, client=self, return_chatlog=return_chatlog)
+        return Chat(
+                    query=query,
+                    persona=persona,
+                    _future=response,
+                    client=self,
+                    return_chatlog=return_chatlog,
+                    return_prompt=return_prompt
+                )
 
     def embed(self, texts: List[str], model: str = None, truncate: str = None) -> Embeddings:
         responses = []

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.4.0',
+                 version='3.5.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -74,3 +74,18 @@ class TestChat(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             prediction.chatlog
+
+    def test_return_prompt(self):
+        prediction = co.chat("Yo what up?", return_prompt=True)
+        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.session_id, str)
+        self.assertIsNotNone(prediction.prompt)
+        self.assertGreaterEqual(len(prediction.prompt), len(prediction.reply))
+
+    def test_return_prompt_false(self):
+        prediction = co.chat("Yo what up?", return_prompt=False)
+        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.session_id, str)
+
+        with self.assertRaises(AttributeError):
+            prediction.prompt


### PR DESCRIPTION
## What this PR does

- Adds `return_prompt` as an option param to co.chat
- Returns the prompt if `return_prompt` is set to true
- Adds unit tests for the new functionality
- Closes CNV-287

## How it was tested
- Unit tests