### PR TITLE
Co.chat - add chatlog override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.5
-- []
+- [#157](https://github.com/cohere-ai/cohere-python/pull/157)
   - Add support for `chatlog_override` parameter for co.Chat
 
 ## 3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5
+- []
+  - Add support for `chatlog_override` parameter for co.Chat
+
 ## 3.4
 - [#154](https://github.com/cohere-ai/cohere-python/pull/154)
   - Add support for `return_chatlog` parameter for co.Chat

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.4.0',
+                 version='3.5.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -74,3 +74,47 @@ class TestChat(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             prediction.chatlog
+
+    def testValidChatlogOverride(self):
+        query = "What about you?"
+        valid_chatlog_overrides = [[
+            {
+                'Bot': 'Hey!'
+            },
+            {
+                'User': 'I am doing great!'
+            },
+            {
+                'Bot': 'That is great to hear!'
+            },
+        ], []]
+
+        for chatlog_override in valid_chatlog_overrides:
+            expected_chatlog = ""
+            for message in chatlog_override:
+                key, value = next(iter(message.items()))
+                expected_chatlog += f"{key}: {value}\n"
+            expected_chatlog += "User: " + query
+
+            prediction = co.chat(query=query, session_id="1234", chatlog_override=chatlog_override, return_chatlog=True)
+
+            self.assertIsInstance(prediction.reply, str)
+            self.assertIsInstance(prediction.session_id, str)
+            self.assertIn(expected_chatlog, prediction.chatlog)
+
+    def testInvalidChatlogOverride(self):
+        invalid_chatlog_overrides = [
+            "invalid",
+            ["invalid"],
+            [{
+                "user": "invalid",
+                "bot": "invalid"
+            }],
+        ]
+
+        for chatlog_override in invalid_chatlog_overrides:
+            with self.assertRaises(cohere.error.CohereError):
+                _ = co.chat(query="What about you?",
+                            session_id="1234",
+                            chatlog_override=chatlog_override,
+                            return_chatlog=True)


### PR DESCRIPTION
## What this PR does

- Adds `chatlog_override` as an option param to co.chat
- Adds unit tests for the new functionality
- Resolves CNV-284

## How it was tested
- Unit tests