### PR TITLE
Co.chat - add remaining params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#158](https://github.com/cohere-ai/cohere-python/pull/158)
   - Add support for `preamble_override` parameter for co.Chat
   - Add support for `return_prompt` parameter for co.Chat
+  - Add support for `username` parameter for co.Chat
   
 ## 3.5
 - [#157](https://github.com/cohere-ai/cohere-python/pull/157)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.6
+- [#158](https://github.com/cohere-ai/cohere-python/pull/158)
+  - Add support for `preamble_override` parameter for co.Chat
+  - Add support for `return_prompt` parameter for co.Chat
+  
 ## 3.5
 - [#157](https://github.com/cohere-ai/cohere-python/pull/157)
   - Add support for `chatlog_override` parameter for co.Chat

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -153,7 +153,8 @@ class Client:
              return_chatlog: bool = False,
              return_prompt: bool = False,
              chatlog_override: List[Dict[str, str]] = None,
-             preamble_override: str = None) -> Chat:
+             preamble_override: str = None,
+             username: str = None) -> Chat:
         """Returns a Chat object with the query reply.
 
         Args:
@@ -165,6 +166,7 @@ class Client:
             return_prompt (bool): (Optional) Whether to return the prompt.
             chatlog_override (List[Dict[str, str]]): (Optional) A list of chatlog entries to override the chatlog.
             preamble_override (str): (Optional) A string to override the preamble.
+            username (str): (Optional) A string to override the username.
 
         Example:
         ```
@@ -194,9 +196,10 @@ class Client:
             session_id="1234",
             chatlog_override=[
                 {'Bot': 'Hey!'},
-                {'User': 'I am doing great!'},
+                {'CustomUser': 'I am doing great!'},
                 {'Bot': 'That is great to hear!'},
             ],
+            username="CustomUser",
             return_chatlog=True)
         print(res.reply)
         print(res.chatlog)
@@ -224,6 +227,7 @@ class Client:
             'return_prompt': return_prompt,
             'chatlog_override': chatlog_override,
             'preamble_override': preamble_override,
+            'username': username,
         }
         response = self._executor.submit(self.__request, cohere.CHAT_URL, json=json_body)
         return Chat(

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -151,7 +151,9 @@ class Client:
              persona: str = "cohere",
              model: str = None,
              return_chatlog: bool = False,
-             chatlog_override: List[Dict[str, str]] = None) -> Chat:
+             return_prompt: bool = False,
+             chatlog_override: List[Dict[str, str]] = None,
+             preamble_override: str = None) -> Chat:
         """Returns a Chat object with the query reply.
 
         Args:
@@ -160,7 +162,9 @@ class Client:
             persona (str): (Optional) The persona to use.
             model (str): (Optional) The model to use for generating the next reply.
             return_chatlog (bool): (Optional) Whether to return the chatlog.
+            return_prompt (bool): (Optional) Whether to return the prompt.
             chatlog_override (List[Dict[str, str]]): (Optional) A list of chatlog entries to override the chatlog.
+            preamble_override (str): (Optional) A string to override the preamble.
 
         Example:
         ```
@@ -176,12 +180,14 @@ class Client:
             session_id="1234",
             persona="fortune",
             model="command-xlarge",
-            return_chatlog=True)
+            return_chatlog=True,
+            return_prompt=True)
         print(res.reply)
         print(res.chatlog)
+        print(res.prompt)
         ```
 
-                Example:
+        Example:
         ```
         res = co.chat(
             query="What about you?",
@@ -195,6 +201,16 @@ class Client:
         print(res.reply)
         print(res.chatlog)
         ```
+
+        Example:
+        ```
+        res = co.chat(
+            query="What about you?",
+            preamble_override="You are a dog who mostly barks",
+            return_chatlog=True)
+            )
+        print(res.reply)
+        print(res.chatlog)
         """
         if chatlog_override is not None:
             self._validate_chatlog_override(chatlog_override)
@@ -205,10 +221,19 @@ class Client:
             'persona': persona,
             'model': model,
             'return_chatlog': return_chatlog,
+            'return_prompt': return_prompt,
             'chatlog_override': chatlog_override,
+            'preamble_override': preamble_override,
         }
         response = self._executor.submit(self.__request, cohere.CHAT_URL, json=json_body)
-        return Chat(query=query, persona=persona, _future=response, client=self, return_chatlog=return_chatlog)
+        return Chat(
+                    query=query,
+                    persona=persona,
+                    _future=response,
+                    client=self,
+                    return_chatlog=return_chatlog,
+                    return_prompt=return_prompt
+                )
 
     def _validate_chatlog_override(self, chatlog_override: List[Dict[str, str]]) -> None:
         if not isinstance(chatlog_override, list):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.6.0',
+                 version='3.7.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.7.0',
+                 version='3.8.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.5.0',
+                 version='3.6.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -118,3 +118,30 @@ class TestChat(unittest.TestCase):
                             session_id="1234",
                             chatlog_override=chatlog_override,
                             return_chatlog=True)
+
+    def test_return_prompt(self):
+        prediction = co.chat("Yo what up?", return_prompt=True)
+        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.session_id, str)
+        self.assertIsNotNone(prediction.prompt)
+        self.assertGreaterEqual(len(prediction.prompt), len(prediction.reply))
+
+    def test_return_prompt_false(self):
+        prediction = co.chat("Yo what up?", return_prompt=False)
+        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.session_id, str)
+
+        with self.assertRaises(AttributeError):
+            prediction.prompt
+
+    def test_preamble_override(self):
+        preamble = "You are a dog who mostly barks"
+        prediction = co.chat("Yo what up?", preamble_override=preamble, return_prompt=True)
+        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.session_id, str)
+        self.assertIn(preamble, prediction.prompt)
+        print(prediction.prompt)
+
+    def test_invalid_preamble_override(self):
+        with self.assertRaises(cohere.CohereError):
+            co.chat("Yo what up?", preamble_override=123).reply

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -145,3 +145,11 @@ class TestChat(unittest.TestCase):
     def test_invalid_preamble_override(self):
         with self.assertRaises(cohere.CohereError):
             co.chat("Yo what up?", preamble_override=123).reply
+
+    def test_username_override(self):
+        username = "CustomUser"
+        prediction = co.chat("Yo what up?", username=username, return_chatlog=True)
+        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.session_id, str)
+        chatlog_starts_with_username = prediction.chatlog.strip().startswith(username)
+        self.assertTrue(chatlog_starts_with_username)


### PR DESCRIPTION
## What this PR does

- Adds `return_prompt` as an option param to co.chat
- Returns the prompt if `return_prompt` is set to true
- Adds `preamble_override` as an option param to co.chat
- Adds unit tests for the new functionalities
- Closes CNV-284

## How it was tested
- Unit tests