### PR TITLE
Removed ability to override API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.0
+- []
+  - Removed ability to override API version
 ## 3.7
 
 - [#164](https://github.com/cohere-ai/cohere-python/pull/164)

--- a/README.md
+++ b/README.md
@@ -50,13 +50,7 @@ print('prediction: {}'.format(prediction.generations[0].text))
 
 ## Versioning
 
-To use the SDK with a specific API version, you can specify it when creating the Cohere Client:
-
-```python
-import cohere
-
-co = cohere.Client('YOUR_API_KEY', '2022-12-06')
-```
+This SDK currently supports v1 of the API. To use the SDK with a specific API version, you need to download the specific version of the SDK tied to the API version you want. Look at the Changelog to see which SDK version to download.
 
 ## Endpoints
 

--- a/cohere/__init__.py
+++ b/cohere/__init__.py
@@ -2,7 +2,7 @@ from .client import Client
 from .error import CohereError
 
 COHERE_API_URL = 'https://api.cohere.ai'
-COHERE_VERSION = '2022-12-06'
+COHERE_VERSION = 'v1'
 COHERE_EMBED_BATCH_SIZE = 96
 CHAT_URL = 'chat'
 CLASSIFY_URL = 'classify'

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -4,7 +4,7 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional, Union
-from urllib.parse import urljoin
+from posixpath import join as posixJoin
 
 import requests
 from requests import Response
@@ -39,7 +39,6 @@ class Client:
 
     def __init__(self,
                  api_key: str,
-                 version: Optional[str] = None,
                  num_workers: int = 64,
                  request_dict: dict = {},
                  check_api_key: bool = True,
@@ -63,13 +62,9 @@ class Client:
         self.request_dict = request_dict
         self.request_source = 'python-sdk'
         self.max_retries = max_retries
+        self.cohere_version = cohere.COHERE_VERSION
         if client_name:
             self.request_source += ":" + client_name
-
-        if version is None:
-            self.cohere_version = cohere.COHERE_VERSION
-        else:
-            self.cohere_version = version
 
         if check_api_key:
             try:
@@ -85,10 +80,8 @@ class Client:
             'Content-Type': 'application/json',
             'Request-Source': 'python-sdk',
         }
-        if self.cohere_version != '':
-            headers['Cohere-Version'] = self.cohere_version
 
-        url = urljoin(self.api_url, cohere.CHECK_API_KEY_URL)
+        url = posixJoin(self.api_url, cohere.CHECK_API_KEY_URL)
         if use_xhr_client:
             response = self.__pyfetch(url, headers, None)
         else:
@@ -456,10 +449,9 @@ class Client:
             'Content-Type': 'application/json',
             'Request-Source': self.request_source,
         }
-        if self.cohere_version != '':
-            headers['Cohere-Version'] = self.cohere_version
 
-        url = urljoin(self.api_url, endpoint)
+        url = posixJoin(self.api_url, self.cohere_version, endpoint)
+
         if use_xhr_client:
             response = self.__pyfetch(url, headers, jsonlib.dumps(json), method=method)
             self.__print_warning_msg(response)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class BinaryDistribution(Distribution):
 
 
 setuptools.setup(name='cohere',
-                 version='3.7.0',
+                 version='5.0.0',
                  author='1vn',
                  author_email='ivan@cohere.ai',
                  description='A Python library for the Cohere API',

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -48,10 +48,6 @@ class TestGenerate(unittest.TestCase):
     def test_no_version_works(self):
         cohere.Client(API_KEY).generate(model='medium', prompt='co:here', max_tokens=1).generations
 
-    def test_invalid_version_fails(self):
-        with self.assertRaises(cohere.CohereError):
-            _ = cohere.Client(API_KEY, 'fake').generate(model='medium', prompt='co:here', max_tokens=1).generations
-
     def test_invalid_key(self):
         with self.assertRaises(cohere.CohereError):
             _ = cohere.Client('invalid')


### PR DESCRIPTION
### What this PR does.
Users can no longer pass in a version to the SDK. We want to support this because the SDK code is only specific to the API version it ships with. By default, the version is set to v1 which is equivalent to the 2022 version we currently have.

Closes OS-44
### Testing
Current unit tests passed. Remove the unit test testing for invalid version since we're presetting that.