### PR TITLE
(WIP - under discussion) Cluster: change wait semantics

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -602,9 +602,6 @@ class Client:
                 Defaults to None.
             interval (float, optional): Wait poll interval in seconds. Defaults to 10.
 
-        Raises:
-            TimeoutError: wait timed out
-
         Returns:
             ClusterJobResult: Clustering job result.
         """
@@ -614,7 +611,7 @@ class Client:
 
         while job.status == 'processing':
             if timeout is not None and time.time() - start_time > timeout:
-                raise TimeoutError(f'wait_for_cluster_job timed out after {timeout} seconds')
+                return job
 
             time.sleep(interval)
             job = self.get_cluster_job(job_id)

--- a/cohere/cluster.py
+++ b/cohere/cluster.py
@@ -104,9 +104,6 @@ class CreateClusterJobResponse(CohereObject):
                 Defaults to None.
             interval (float, optional): Wait poll interval in seconds. Defaults to 10.
 
-        Raises:
-            TimeoutError: wait timed out
-
         Returns:
             ClusterJobResult: Clustering job result.
         """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,12 +1,14 @@
 import time
 import unittest
+from typing import Optional
 
 from utils import get_api_key, in_ci
 
 import cohere
 from cohere.cluster import ClusterJobResult
 
-INPUT_FILE = "gs://cohere-dev-central-2/cluster_tests/all_datasets/reddit_500.jsonl"
+VALID_INPUT_FILE = "gs://cohere-dev-central-2/cluster_tests/all_datasets/reddit_500.jsonl"
+BAD_INPUT_FILE = "./local-file.jsonl"
 
 
 class TestClient(unittest.TestCase):
@@ -15,7 +17,7 @@ class TestClient(unittest.TestCase):
     def test_create_cluster_job(self):
         co = self.create_co()
         create_res = co.create_cluster_job(
-            INPUT_FILE,
+            VALID_INPUT_FILE,
             min_cluster_size=3,
             threshold=0.5,
         )
@@ -28,7 +30,7 @@ class TestClient(unittest.TestCase):
             time.sleep(5)
             job = co.get_cluster_job(create_res.job_id)
 
-        self.check_job_result(job)
+        self.check_job_result(job, status='complete')
 
     def test_get_cluster_job(self):
         co = self.create_co()
@@ -41,65 +43,93 @@ class TestClient(unittest.TestCase):
         jobs = co.list_cluster_jobs()
         assert len(jobs) > 0
         for job in jobs:
-            self.check_job_result(job, completed=False)
+            self.check_job_result(job)
 
     @unittest.skipIf(in_ci(), "can sometimes fail due to duration variation")
     def test_wait_for_cluster_job_succeeds(self):
         co = self.create_co()
         create_res = co.create_cluster_job(
-            INPUT_FILE,
+            VALID_INPUT_FILE,
             min_cluster_size=3,
             threshold=0.5,
         )
 
         job = co.wait_for_cluster_job(create_res.job_id, timeout=60, interval=5)
-        self.check_job_result(job)
+        self.check_job_result(job, status='complete')
+
+    @unittest.skipIf(in_ci(), "can sometimes fail due to duration variation")
+    def test_wait_for_cluster_job_fails(self):
+        co = self.create_co()
+        create_res = co.create_cluster_job(
+            BAD_INPUT_FILE,
+            min_cluster_size=3,
+            threshold=0.5,
+        )
+
+        job = co.wait_for_cluster_job(create_res.job_id, timeout=60, interval=5)
+        self.check_job_result(job, status='failed')
 
     def test_wait_for_cluster_job_times_out(self):
         co = self.create_co()
         create_res = co.create_cluster_job(
-            INPUT_FILE,
+            VALID_INPUT_FILE,
             min_cluster_size=3,
             threshold=0.5,
         )
 
         job = co.wait_for_cluster_job(create_res.job_id, timeout=5, interval=2)
-        self.check_job_result(job, completed=False)
+        self.check_job_result(job, status='processing')
 
     @unittest.skipIf(in_ci(), "can sometimes fail due to duration variation")
     def test_job_wait_method_succeeds(self):
         co = self.create_co()
         create_res = co.create_cluster_job(
-            INPUT_FILE,
+            VALID_INPUT_FILE,
             min_cluster_size=3,
             threshold=0.5,
         )
 
         job = create_res.wait(timeout=60, interval=5)
-        self.check_job_result(job)
+        self.check_job_result(job, status='complete')
+
+    @unittest.skipIf(in_ci(), "can sometimes fail due to duration variation")
+    def test_job_wait_method_fails(self):
+        co = self.create_co()
+        create_res = co.create_cluster_job(
+            BAD_INPUT_FILE,
+            min_cluster_size=3,
+            threshold=0.5,
+        )
+
+        job = create_res.wait(timeout=60, interval=5)
+        self.check_job_result(job, status='failed')
 
     def test_job_wait_method_times_out(self):
         co = self.create_co()
         create_res = co.create_cluster_job(
-            INPUT_FILE,
+            VALID_INPUT_FILE,
             min_cluster_size=3,
             threshold=0.5,
         )
 
         job = create_res.wait(timeout=5, interval=2)
-        self.check_job_result(job, completed=False)
+        self.check_job_result(job, status='processing')
 
     def create_co(self) -> cohere.Client:
         return cohere.Client(get_api_key(), check_api_key=False, client_name='test')
 
-    def check_job_result(self, job: ClusterJobResult, completed: bool = True):
+    def check_job_result(self, job: ClusterJobResult, status: Optional[str] = None):
         assert job.job_id
-        assert job.status
 
-        if completed:
-            assert job.status == 'complete'
+        if status is None:
+            return
+
+        assert job.status == status
+        if job.status == 'complete':
             assert job.output_clusters_url
             assert job.output_outliers_url
             assert job.clusters
         else:
-            assert job.status != 'complete'
+            assert not job.output_clusters_url
+            assert not job.output_outliers_url
+            assert not job.clusters

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -63,10 +63,8 @@ class TestClient(unittest.TestCase):
             threshold=0.5,
         )
 
-        def wait():
-            co.wait_for_cluster_job(create_res.job_id, timeout=5, interval=2)
-
-        self.assertRaises(TimeoutError, wait)
+        job = co.wait_for_cluster_job(create_res.job_id, timeout=5, interval=2)
+        self.check_job_result(job, completed=False)
 
     @unittest.skipIf(in_ci(), "can sometimes fail due to duration variation")
     def test_job_wait_method_succeeds(self):
@@ -88,10 +86,8 @@ class TestClient(unittest.TestCase):
             threshold=0.5,
         )
 
-        def wait():
-            create_res.wait(timeout=5, interval=2)
-
-        self.assertRaises(TimeoutError, wait)
+        job = create_res.wait(timeout=5, interval=2)
+        self.check_job_result(job, completed=False)
 
     def create_co(self) -> cohere.Client:
         return cohere.Client(get_api_key(), check_api_key=False, client_name='test')
@@ -105,3 +101,5 @@ class TestClient(unittest.TestCase):
             assert job.output_clusters_url
             assert job.output_outliers_url
             assert job.clusters
+        else:
+            assert job.status != 'complete'


### PR DESCRIPTION
Users are confused by `wait` timing out by raising `TimeoutError` instead of returning job in "processing" state.