### PR TITLE
dont raise exception on retry limit, preserve original error msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.2
+- [#183](https://github.com/cohere-ai/cohere-python/pull/183)
+  - Better error messages for synchronous client
+
 ## 4.0.1
 - [#181](https://github.com/cohere-ai/cohere-python/pull/181)
   - Allow Python >=3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.0.1"
+version = "4.0.2"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"


### PR DESCRIPTION
The async client error code works as expected. 