### PR TITLE
Validate API key without API call

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -28,6 +28,7 @@ from cohere.responses.embeddings import Embeddings
 from cohere.responses.feedback import Feedback
 from cohere.responses.rerank import Reranking
 from cohere.responses.summarize import SummarizeResponse
+from cohere.utils import is_api_key_valid
 
 
 class Client:
@@ -75,22 +76,7 @@ class Client:
         """Checks the api key.
         Happens automatically during Client initialization, but not in AsyncClient
         """
-        headers = {
-            "Authorization": "BEARER {}".format(self.api_key),
-            "Content-Type": "application/json",
-            "Request-Source": "python-sdk",
-        }
-
-        url = f"{self.api_url}/{cohere.CHECK_API_KEY_URL}"
-        response = requests.request("POST", url, headers=headers)
-
-        try:
-            res = jsonlib.loads(response.text)
-        except Exception:
-            raise CohereAPIError.from_response(response)
-        if "message" in res.keys():  # has errors
-            raise CohereAPIError(message=res["message"], http_status=response.status_code, headers=response.headers)
-        return res
+        return {"valid": is_api_key_valid(self.api_key)}
 
     def batch_generate(self, prompts: List[str], **kwargs) -> List[Generations]:
         """A batched version of generate with multiple prompts."""

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -31,7 +31,7 @@ from cohere.responses import (
 )
 from cohere.responses.chat import AsyncChat
 from cohere.responses.classify import Example as ClassifyExample
-from cohere.utils import np_json_dumps
+from cohere.utils import is_api_key_valid, np_json_dumps
 
 JSON = Union[Dict, List]
 
@@ -104,7 +104,7 @@ class AsyncClient(Client):
 
     # API methods
     async def check_api_key(self) -> Dict[str, bool]:
-        return await self._request(endpoint=None, full_url=posixpath.join(self.api_url, cohere.CHECK_API_KEY_URL))
+        return {"valid": is_api_key_valid(self.api_key)}
 
     async def batch_generate(self, prompts: List[str], return_exceptions=False, **kwargs) -> List[Generations]:
         """return_exceptions is passed to asyncio.gather"""

--- a/cohere/utils.py
+++ b/cohere/utils.py
@@ -1,4 +1,7 @@
 import json
+import typing
+
+from cohere.error import CohereError
 
 try:  # numpy is optional, but support json encoding if the user has it
     import numpy as np
@@ -32,3 +35,12 @@ except:
 
 def np_json_dumps(data, **kwargs):
     return json.dumps(data, cls=CohereJsonEncoder, **kwargs)
+
+
+def is_api_key_valid(key: typing.Optional[str]) -> bool:
+    if not key:
+        raise CohereError(
+            "No API key provided. Provide the API key in the client initialisation or the CO_API_KEY environment variable."  # noqa: E501
+        )
+
+    return True

--- a/tests/async/test_async_client.py
+++ b/tests/async/test_async_client.py
@@ -12,12 +12,13 @@ async def test_async_enter():
 
 
 @pytest.mark.asyncio
-async def test_async_enter_invalid_key():
-    cli = cohere.AsyncClient(api_key="invalid")
+async def test_async_enter_invalid_key(monkeypatch):
+    api_key = ""
+    monkeypatch.setenv("CO_API_KEY", api_key)
+    cli = cohere.AsyncClient(api_key=api_key)
     with pytest.raises(cohere.CohereError) as exc:
         async with cli as co:
             pass
-    assert "invalid API key" in str(exc)
 
 
 @pytest.mark.asyncio

--- a/tests/sync/test_generate.py
+++ b/tests/sync/test_generate.py
@@ -1,4 +1,6 @@
+import os
 import unittest
+from unittest import mock
 
 from utils import get_api_key
 
@@ -51,8 +53,9 @@ class TestGenerate(unittest.TestCase):
         cohere.Client(API_KEY).generate(model="medium", prompt="co:here", max_tokens=1).generations
 
     def test_invalid_key(self):
-        with self.assertRaises(cohere.CohereError):
-            _ = cohere.Client("invalid")
+        api_key = ""
+        with self.assertRaises(cohere.CohereError), mock.patch.dict(os.environ, {"CO_API_KEY": api_key}):
+            _ = cohere.Client(api_key)
 
     def test_preset_success(self):
         prediction = co.generate(preset="SDK-PRESET-TEST-t94jfm")

--- a/tests/test_is_api_key_valid.py
+++ b/tests/test_is_api_key_valid.py
@@ -1,0 +1,23 @@
+import typing
+
+import pytest
+
+from cohere.error import CohereError
+from cohere.utils import is_api_key_valid
+
+
+@pytest.mark.parametrize(
+    "api_key, expect_valid, expect_error",
+    [
+        pytest.param("valid", True, False, id="valid key"),
+        pytest.param("", False, True, id="empty key"),
+        pytest.param(None, False, True, id="no key"),
+    ],
+)
+def test_is_api_key_valid(api_key: typing.Optional[str], expect_valid: bool, expect_error: bool):
+    if expect_error:
+        with pytest.raises(CohereError):
+            is_api_key_valid(api_key)
+    else:
+        actual = is_api_key_valid(api_key)
+        assert expect_valid == actual


### PR DESCRIPTION
This PR will change how we validate API keys. Instead of making an API call to a special endpoint it will perform a limited amount of validation locally. Other types of validation, those that can't be performed locally, will instead happen on calls to real endpoints. The motivation behind this is to bring this SDK inline with our other SDKs.