### PR TITLE
Remove wrong "Embedding" class used for type hinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.1
+- [#190](https://github.com/cohere-ai/cohere-python/pull/190)
+  - Remove wrong "Embedding" class used for type hinting
+
 ## 4.1.0
 - [#188](https://github.com/cohere-ai/cohere-python/pull/188)
   - Add `stream` parameter to chat, and relevant return object.
@@ -10,7 +14,7 @@
 ## 4.0.6
 - [#187](https://github.com/cohere-ai/cohere-python/pull/187)
   - Refactor feedback to be generate specific
-  
+
 ## 4.0.5
 - [#186](https://github.com/cohere-ai/cohere-python/pull/186)
   - Added warnings support for meta response

--- a/cohere/responses/__init__.py
+++ b/cohere/responses/__init__.py
@@ -6,7 +6,7 @@ from cohere.responses.cluster import (
     CreateClusterJobResponse,
 )
 from cohere.responses.detectlang import DetectLanguageResponse, Language
-from cohere.responses.embeddings import Embedding, Embeddings
+from cohere.responses.embeddings import Embeddings
 from cohere.responses.feedback import GenerateFeedbackResponse
 from cohere.responses.generation import Generation, Generations, StreamingGenerations
 from cohere.responses.rerank import RerankDocument, Reranking, RerankResult

--- a/cohere/responses/embeddings.py
+++ b/cohere/responses/embeddings.py
@@ -3,19 +3,8 @@ from typing import Any, Dict, Iterator, List, Optional
 from cohere.responses.base import CohereObject
 
 
-class Embedding(CohereObject):
-    def __init__(self, embedding: List[float]) -> None:
-        self.embedding = embedding
-
-    def __iter__(self) -> Iterator:
-        return iter(self.embedding)
-
-    def __len__(self) -> int:
-        return len(self.embedding)
-
-
 class Embeddings(CohereObject):
-    def __init__(self, embeddings: List[Embedding], meta: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, embeddings: List[List[float]], meta: Optional[Dict[str, Any]] = None) -> None:
         self.embeddings = embeddings
         self.meta = meta
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.1.0"
+version = "4.1.1"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"


### PR DESCRIPTION
The `Embeddings` response has `embeddings` property which is just a 2d float list, not a 1d list of `Embedding` objects (which are supposed to contain the 2nd dimension list).
This can be confirmed by the following test: https://github.com/cohere-ai/cohere-python/blob/cdaefa80475c85f35f572ec5be8dec8fb97d746d/tests/sync/test_embed.py#L37-L42

This is not major, it's only inconvenient because it provides wrong type hinting 