### PR TITLE
Fix duplicate call in client.py

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -552,7 +552,6 @@ class Client:
             if stream:
                 return session.request(method, url, headers=headers, json=json, **self.request_dict, stream=True)
 
-            response = session.request(method, url, headers=headers, json=json, **self.request_dict)
             try:
                 response = session.request(
                     method, url, headers=headers, json=json, timeout=self.timeout, **self.request_dict


### PR DESCRIPTION
Currently there is a significant problem that causes especially problems for trial API users with limited rates.
Instead of a single access of the cohere endpoint, a request is issued *twice* instead, which means that rate limits are effectively cut in half.

Additionally, this also causes server load to be doubled, which I believe should be fixed ASAP for the interest of everyone involved ;-)

Removing either the suggested line (or the other call just below the affected line) should fix this issue.