### PR TITLE
Add new bool final state field for cluster, and wait based on it

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -619,6 +619,7 @@ class Client:
             raise ValueError('"job_id" is empty')
 
         response = self._request(f"{cohere.CLUSTER_JOBS_URL}/{job_id}", method="GET")
+
         return ClusterJobResult.from_dict(response)
 
     def list_cluster_jobs(self) -> List[ClusterJobResult]:
@@ -655,7 +656,7 @@ class Client:
         start_time = time.time()
         job = self.get_cluster_job(job_id)
 
-        while job.status == "processing":
+        while not job.is_final_state:
             if timeout is not None and time.time() - start_time > timeout:
                 raise TimeoutError(f"wait_for_cluster_job timed out after {timeout} seconds")
 

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -438,7 +438,7 @@ class AsyncClient(Client):
         start_time = time.time()
         job = await self.get_cluster_job(job_id)
 
-        while job.status == "processing":
+        while not job.is_final_state:
             if timeout is not None and time.time() - start_time > timeout:
                 raise TimeoutError(f"wait_for_cluster_job timed out after {timeout} seconds")
 

--- a/cohere/responses/cluster.py
+++ b/cohere/responses/cluster.py
@@ -38,6 +38,7 @@ class Cluster(CohereObject):
 class ClusterJobResult(CohereObject):
     job_id: str
     status: str
+    is_final_state: bool
     output_clusters_url: Optional[str]
     output_outliers_url: Optional[str]
     clusters: Optional[List[Cluster]]
@@ -52,6 +53,7 @@ class ClusterJobResult(CohereObject):
         output_outliers_url: Optional[str],
         clusters: Optional[List[Cluster]],
         error: Optional[str],
+        is_final_state: Optional[bool] = None,
         meta: Optional[Dict[str, Any]] = None,
     ):
         # convert empty string to `None`
@@ -62,6 +64,7 @@ class ClusterJobResult(CohereObject):
 
         self.job_id = job_id
         self.status = status
+        self.is_final_state = is_final_state
         self.output_clusters_url = output_clusters_url
         self.output_outliers_url = output_outliers_url
         self.clusters = clusters
@@ -74,9 +77,17 @@ class ClusterJobResult(CohereObject):
             clusters = None
         else:
             clusters = [Cluster.from_dict(c) for c in data["clusters"]]
+
+        is_final_state = data.get("is_final_state")
+        status = data["status"]
+        # TODO: remove this. temp for backward compatibility until the `is_final_state` field is added to the API
+        if is_final_state is None:
+            is_final_state = status in ["completed", "failed"]
+
         return ClusterJobResult(
             job_id=data["job_id"],
-            status=data["status"],
+            status=status,
+            is_final_state=is_final_state,
             output_clusters_url=data["output_clusters_url"],
             output_outliers_url=data["output_outliers_url"],
             clusters=clusters,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.1.3"
+version = "4.1.4"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"

--- a/tests/async/test_async_cluster.py
+++ b/tests/async/test_async_cluster.py
@@ -23,7 +23,7 @@ async def test_async_create_cluster_job(async_client: AsyncClient):
     job = await async_client.get_cluster_job(create_res.job_id)
     start = time.time()
 
-    while job.status == "processing":
+    while not job.is_final_state:
         if time.time() - start > 60:  # 60s timeout
             raise TimeoutError()
         await asyncio.sleep(5)

--- a/tests/sync/test_cluster.py
+++ b/tests/sync/test_cluster.py
@@ -23,7 +23,7 @@ class TestClient(unittest.TestCase):
         job = co.get_cluster_job(create_res.job_id)
         start = time.time()
 
-        while job.status == "processing":
+        while not job.is_final_state:
             if time.time() - start > 60:  # 60s timeout
                 raise TimeoutError()
             time.sleep(5)


### PR DESCRIPTION
The bit in the response is temporary. Should be removed once the field is returned properly in the API.
This is released first to allow sometime for our users to update the SDK first without the new status of `queued` introduction breaking their "wait for job" code.