### PR TITLE
Add `CO_API_URL` env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,11 @@ You can run tests locally using:
 python -m pytest
 ```
 
-
+You can configure a different base url with:
+```bash
+CO_API_URL="https://localhost:8050" python3 myprogram
+```
+or
+```python
+cohere.COHERE_API_URL = "https://localhost:8050" # Place before client initilization
+```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ python -m pytest
 
 You can configure a different base url with:
 ```bash
-CO_API_URL="https://localhost:8050" python3 myprogram
+CO_API_URL="https://localhost:8050" python3 foo.py
 ```
 or
 ```python

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -57,7 +57,7 @@ class Client:
         timeout: int = 120,
     ) -> None:
         self.api_key = api_key or os.getenv("CO_API_KEY")
-        self.api_url = s.getenv("CO_API_URL", cohere.COHERE_API_URL)
+        self.api_url = os.getenv("CO_API_URL", cohere.COHERE_API_URL)
         self.batch_size = cohere.COHERE_EMBED_BATCH_SIZE
         self._executor = ThreadPoolExecutor(num_workers)
         self.num_workers = num_workers

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -57,7 +57,7 @@ class Client:
         timeout: int = 120,
     ) -> None:
         self.api_key = api_key or os.getenv("CO_API_KEY")
-        self.api_url = cohere.COHERE_API_URL
+        self.api_url = s.getenv("CO_API_URL", cohere.COHERE_API_URL)
         self.batch_size = cohere.COHERE_EMBED_BATCH_SIZE
         self._executor = ThreadPoolExecutor(num_workers)
         self.num_workers = num_workers

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -60,7 +60,7 @@ class AsyncClient(Client):
         timeout=120,
     ) -> None:
         self.api_key = api_key or os.getenv("CO_API_KEY")
-        self.api_url = cohere.COHERE_API_URL
+        self.api_url = os.getenv("CO_API_URL", cohere.COHERE_API_URL)
         self.batch_size = cohere.COHERE_EMBED_BATCH_SIZE
         self.num_workers = num_workers
         self.request_dict = request_dict

--- a/tests/sync/test_classify.py
+++ b/tests/sync/test_classify.py
@@ -100,7 +100,7 @@ class TestClassify(unittest.TestCase):
         self.assertEqual(prediction.classifications[0].prediction, "fruit")
         self.assertEqual(prediction.classifications[1].prediction, "color")
 
-    @pytest.mark.skipif(os.getenv("CO_API_URL"), reason="relies on preset existing in prod")
+    @pytest.mark.skipif(bool(os.getenv("CO_API_URL")), reason="relies on preset existing in prod")
     def test_preset_success(self):
         prediction = co.classify(preset="SDK-TESTS-PRESET-rfa6h3")
         self.assertIsInstance(prediction.classifications, list)

--- a/tests/sync/test_classify.py
+++ b/tests/sync/test_classify.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import pytest

--- a/tests/sync/test_classify.py
+++ b/tests/sync/test_classify.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 from utils import get_api_key
 
 import cohere

--- a/tests/sync/test_classify.py
+++ b/tests/sync/test_classify.py
@@ -98,6 +98,7 @@ class TestClassify(unittest.TestCase):
         self.assertEqual(prediction.classifications[0].prediction, "fruit")
         self.assertEqual(prediction.classifications[1].prediction, "color")
 
+    @pytest.mark.skipif(os.getenv("CO_API_URL"), reason="relies on preset existing in prod")
     def test_preset_success(self):
         prediction = co.classify(preset="SDK-TESTS-PRESET-rfa6h3")
         self.assertIsInstance(prediction.classifications, list)

--- a/tests/sync/test_classify.py
+++ b/tests/sync/test_classify.py
@@ -1,7 +1,6 @@
 import unittest
 
 import pytest
-
 from utils import get_api_key
 
 import cohere

--- a/tests/sync/test_generate.py
+++ b/tests/sync/test_generate.py
@@ -3,7 +3,6 @@ import unittest
 from unittest import mock
 
 import pytest
-
 from utils import get_api_key
 
 import cohere

--- a/tests/sync/test_generate.py
+++ b/tests/sync/test_generate.py
@@ -2,6 +2,8 @@ import os
 import unittest
 from unittest import mock
 
+import pytest
+
 from utils import get_api_key
 
 import cohere

--- a/tests/sync/test_generate.py
+++ b/tests/sync/test_generate.py
@@ -57,6 +57,7 @@ class TestGenerate(unittest.TestCase):
         with self.assertRaises(cohere.CohereError), mock.patch.dict(os.environ, {"CO_API_KEY": api_key}):
             _ = cohere.Client(api_key)
 
+    @pytest.mark.skipif(os.getenv("CO_API_URL"), reason="relies on preset existing in prod")
     def test_preset_success(self):
         prediction = co.generate(preset="SDK-PRESET-TEST-t94jfm")
         self.assertIsInstance(prediction.generations[0].text, str)

--- a/tests/sync/test_generate.py
+++ b/tests/sync/test_generate.py
@@ -58,7 +58,7 @@ class TestGenerate(unittest.TestCase):
         with self.assertRaises(cohere.CohereError), mock.patch.dict(os.environ, {"CO_API_KEY": api_key}):
             _ = cohere.Client(api_key)
 
-    @pytest.mark.skipif(os.getenv("CO_API_URL"), reason="relies on preset existing in prod")
+    @pytest.mark.skipif(bool(os.getenv("CO_API_URL")), reason="relies on preset existing in prod")
     def test_preset_success(self):
         prediction = co.generate(preset="SDK-PRESET-TEST-t94jfm")
         self.assertIsInstance(prediction.generations[0].text, str)


### PR DESCRIPTION
Allow passing the CO_API_URL env var to control which base url the client uses. Useful internally for testing against different deployment environments. I named it CO_API_URL to follow the conventions of existing CO_API_KEY.

Fixes PTS-4212 and PTS-4211