### PR TITLE
Cluster: update cluster algorithm to add hdbscan parameters

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -645,14 +645,21 @@ class Client:
         embeddings_url: str,
         threshold: Optional[float] = None,
         min_cluster_size: Optional[int] = None,
+        n_neighbors: Optional[int] = None,
+        is_deterministic: Optional[bool] = None,
     ) -> CreateClusterJobResponse:
         """Create clustering job.
 
         Args:
             embeddings_url (str): File with embeddings to cluster.
             threshold (Optional[float], optional): Similarity threshold above which two texts are deemed to belong in
-                the same cluster. Defaults to None.
-            min_cluster_size (Optional[int], optional): Minimum number of elements in a cluster. Defaults to None.
+                the same cluster. Defaults to 0.75.
+            min_cluster_size (Optional[int], optional): Minimum number of elements in a cluster. Defaults to 10.
+            n_neighbors (Optional[int], optional): Number of nearest neighbors used by UMAP to establish the
+                local structure of the data. Defaults to 15. For more information, please refer to
+                https://umap-learn.readthedocs.io/en/latest/parameters.html#n-neighbors
+            is_deterministic (Optional[bool], optional): Determines whether the output of the cluster job is
+                deterministic. Defaults to True.
 
         Returns:
             CreateClusterJobResponse: Created clustering job handler
@@ -662,6 +669,8 @@ class Client:
             "embeddings_url": embeddings_url,
             "threshold": threshold,
             "min_cluster_size": min_cluster_size,
+            "n_neighbors": n_neighbors,
+            "is_deterministic": is_deterministic,
         }
 
         response = self._request(cohere.CLUSTER_JOBS_URL, json=json_body)

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -405,14 +405,21 @@ class AsyncClient(Client):
         embeddings_url: str,
         threshold: Optional[float] = None,
         min_cluster_size: Optional[int] = None,
+        n_neighbors: Optional[int] = None,
+        is_deterministic: Optional[bool] = None,
     ) -> AsyncCreateClusterJobResponse:
         """Create clustering job.
 
         Args:
             embeddings_url (str): File with embeddings to cluster.
             threshold (Optional[float], optional): Similarity threshold above which two texts are deemed to belong in
-                the same cluster. Defaults to None.
-            min_cluster_size (Optional[int], optional): Minimum number of elements in a cluster. Defaults to None.
+                the same cluster. Defaults to 0.75.
+            min_cluster_size (Optional[int], optional): Minimum number of elements in a cluster. Defaults to 10.
+            n_neighbors (Optional[int], optional): Number of nearest neighbors used by UMAP to establish the
+                local structure of the data. Defaults to 15. For more information, please refer to
+                https://umap-learn.readthedocs.io/en/latest/parameters.html#n-neighbors
+            is_deterministic (Optional[bool], optional): Determines whether the output of the cluster job is
+                deterministic. Defaults to True.
 
         Returns:
             CreateClusterJobResponse: Created clustering job handler
@@ -422,6 +429,8 @@ class AsyncClient(Client):
             "embeddings_url": embeddings_url,
             "threshold": threshold,
             "min_cluster_size": min_cluster_size,
+            "n_neighbors": n_neighbors,
+            "is_deterministic": is_deterministic,
         }
         response = await self._request(cohere.CLUSTER_JOBS_URL, json=json_body)
         return AsyncCreateClusterJobResponse.from_dict(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.1.4"
+version = "4.1.5"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"


### PR DESCRIPTION
This adds UMAP+HDBSCAN parameters to create_cluster_job. `threshold` used for community_detection is kept for now, but it will be removed in a later release and tests updated.