### PR TITLE
Add co.codebook endpoint

### DIFF
--- a/cohere/__init__.py
+++ b/cohere/__init__.py
@@ -9,6 +9,7 @@ API_VERSION = "1"
 COHERE_EMBED_BATCH_SIZE = 96
 CHAT_URL = "chat"
 CLASSIFY_URL = "classify"
+CODEBOOK_URL = "embed-codebook"
 DETECT_LANG_URL = "detect-language"
 EMBED_URL = "embed"
 GENERATE_FEEDBACK_URL = "feedback/generate"

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -16,6 +16,7 @@ from cohere.logging import logger
 from cohere.responses import (
     Classification,
     Classifications,
+    Codebook,
     Detokenization,
     Generations,
     StreamingGenerations,
@@ -282,6 +283,20 @@ class Client:
             meta = result["meta"] if not meta else meta
 
         return Embeddings(responses, meta)
+
+    def codebook(self, model: Optional[str] = None, compression_codebook: Optional[str] = "default",) -> Codebook:
+        """Returns a codebook object for the provided model. Visit https://cohere.ai/embed to learn about compressed embeddings and codebooks.
+
+        Args:
+            model (str): (Optional) The model ID to use for embedding the text.
+            compression_codebook (str): (Optional) The compression codebook to use for compressed embeddings. Defaults to "default".
+        """
+        json_body = {
+            "model": model,
+            "compression_codebook": compression_codebook,
+        }
+        response =  self._request(cohere.CODEBOOK_URL, json=json_body)
+        return Codebook(response['codebook'], response["meta"])
 
     def classify(
         self,

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -284,7 +284,11 @@ class Client:
 
         return Embeddings(responses, meta)
 
-    def codebook(self, model: Optional[str] = None, compression_codebook: Optional[str] = "default",) -> Codebook:
+    def codebook(
+        self,
+        model: Optional[str] = None,
+        compression_codebook: Optional[str] = "default",
+    ) -> Codebook:
         """Returns a codebook object for the provided model. Visit https://cohere.ai/embed to learn about compressed embeddings and codebooks.
 
         Args:
@@ -295,8 +299,8 @@ class Client:
             "model": model,
             "compression_codebook": compression_codebook,
         }
-        response =  self._request(cohere.CODEBOOK_URL, json=json_body)
-        return Codebook(response['codebook'], response["meta"])
+        response = self._request(cohere.CODEBOOK_URL, json=json_body)
+        return Codebook(response["codebook"], response["meta"])
 
     def classify(
         self,

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -17,10 +17,10 @@ from cohere.error import CohereAPIError, CohereConnectionError, CohereError
 from cohere.logging import logger
 from cohere.responses import (
     AsyncCreateClusterJobResponse,
-    Codebook,
     Classification,
     Classifications,
     ClusterJobResult,
+    Codebook,
     DetectLanguageResponse,
     Detokenization,
     Embeddings,
@@ -220,7 +220,11 @@ class AsyncClient(Client):
         embeddings = Embeddings([e for res in responses for e in res["embeddings"]], meta)  # concatenate results
         return embeddings
 
-    async def codebook(self, model: Optional[str] = None, compression_codebook: Optional[str] = "default",) -> Codebook:
+    async def codebook(
+        self,
+        model: Optional[str] = None,
+        compression_codebook: Optional[str] = "default",
+    ) -> Codebook:
         """Returns a codebook object for the provided model. Visit https://cohere.ai/embed to learn about compressed embeddings and codebooks.
 
         Args:
@@ -232,7 +236,7 @@ class AsyncClient(Client):
             "compression_codebook": compression_codebook,
         }
         response = await self._request(cohere.CODEBOOK_URL, json=json_body)
-        return Codebook(response['codebook'], response["meta"])
+        return Codebook(response["codebook"], response["meta"])
 
     async def classify(
         self,

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -17,6 +17,7 @@ from cohere.error import CohereAPIError, CohereConnectionError, CohereError
 from cohere.logging import logger
 from cohere.responses import (
     AsyncCreateClusterJobResponse,
+    Codebook,
     Classification,
     Classifications,
     ClusterJobResult,
@@ -218,6 +219,20 @@ class AsyncClient(Client):
 
         embeddings = Embeddings([e for res in responses for e in res["embeddings"]], meta)  # concatenate results
         return embeddings
+
+    async def codebook(self, model: Optional[str] = None, compression_codebook: Optional[str] = "default",) -> Codebook:
+        """Returns a codebook object for the provided model. Visit https://cohere.ai/embed to learn about compressed embeddings and codebooks.
+
+        Args:
+            model (str): (Optional) The model ID to use for embedding the text.
+            compression_codebook (str): (Optional) The compression codebook to use for compressed embeddings. Defaults to "default".
+        """
+        json_body = {
+            "model": model,
+            "compression_codebook": compression_codebook,
+        }
+        response = await self._request(cohere.CODEBOOK_URL, json=json_body)
+        return Codebook(response['codebook'], response["meta"])
 
     async def classify(
         self,

--- a/cohere/responses/__init__.py
+++ b/cohere/responses/__init__.py
@@ -5,6 +5,7 @@ from cohere.responses.cluster import (
     ClusterJobResult,
     CreateClusterJobResponse,
 )
+from cohere.responses.codebook import Codebook
 from cohere.responses.detectlang import DetectLanguageResponse, Language
 from cohere.responses.embeddings import Embeddings
 from cohere.responses.feedback import (

--- a/cohere/responses/codebook.py
+++ b/cohere/responses/codebook.py
@@ -1,0 +1,15 @@
+from typing import Any, Dict, Iterator, List, Optional
+
+from cohere.responses.base import CohereObject
+
+
+class Codebook(CohereObject):
+    def __init__(self, codebook: List[List[List[float]]], meta: Optional[Dict[str, Any]] = None) -> None:
+        self.codebook = codebook
+        self.meta = meta
+
+    def __iter__(self) -> Iterator:
+        return iter(self.codebook)
+
+    def __len__(self) -> int:
+        return len(self.codebook)

--- a/tests/async/test_async_codebook.py
+++ b/tests/async/test_async_codebook.py
@@ -1,0 +1,13 @@
+import pytest
+
+from cohere.responses import Codebook
+
+
+@pytest.mark.asyncio
+async def test_async_codebook_basic(async_client):
+    codebook = await async_client.codebook(model="multilingual-22-12")
+    assert len(codebook) == 96
+    assert isinstance(codebook, Codebook)
+    assert codebook.meta
+    assert codebook.meta["api_version"]
+    assert codebook.meta["api_version"]["version"]

--- a/tests/async/test_async_codebook.py
+++ b/tests/async/test_async_codebook.py
@@ -2,6 +2,7 @@ import pytest
 
 from cohere.responses import Codebook
 
+
 @pytest.mark.asyncio
 async def test_async_multiple_codebook(async_client):
     compression_codebooks = {
@@ -24,6 +25,7 @@ async def test_async_multiple_codebook(async_client):
         assert codebook.meta
         assert codebook.meta["api_version"]["version"]
         assert codebook.meta["api_version"]
+
 
 @pytest.mark.asyncio
 async def test_async_codebook_default(async_client):

--- a/tests/async/test_async_codebook.py
+++ b/tests/async/test_async_codebook.py
@@ -6,10 +6,10 @@ from cohere.responses import Codebook
 @pytest.mark.asyncio
 async def test_async_multiple_codebook(async_client):
     compression_codebooks = {
-        "32x": (96, 256, 8),
-        "48x": (64, 256, 12),
-        "64x": (48, 256, 16),
-        "96x": (32, 256, 24),
+        "PQ32x": (96, 256, 8),
+        "PQ48x": (64, 256, 12),
+        "PQ64x": (48, 256, 16),
+        "PQ96x": (32, 256, 24),
     }
     for cb, (segments, num_centroids, length) in compression_codebooks.items():
         codebook = await async_client.codebook(

--- a/tests/async/test_async_codebook.py
+++ b/tests/async/test_async_codebook.py
@@ -2,9 +2,31 @@ import pytest
 
 from cohere.responses import Codebook
 
+@pytest.mark.asyncio
+async def test_async_multiple_codebook(async_client):
+    compression_codebooks = {
+        "32x": (96, 256, 8),
+        "48x": (64, 256, 12),
+        "64x": (48, 256, 16),
+        "96x": (32, 256, 24),
+    }
+    for cb, (segments, num_centroids, length) in compression_codebooks.items():
+        codebook = await async_client.codebook(
+            model="multilingual-22-12",
+            compression_codebook=cb,
+        )
+        assert isinstance(codebook, Codebook)
+        assert isinstance(codebook.codebook[0], list)
+        assert isinstance(codebook.codebook[0][0], list)
+        assert len(codebook.codebook) == segments
+        assert len(codebook.codebook[0]) == num_centroids
+        assert len(codebook.codebook[0][0]) == length
+        assert codebook.meta
+        assert codebook.meta["api_version"]["version"]
+        assert codebook.meta["api_version"]
 
 @pytest.mark.asyncio
-async def test_async_codebook_basic(async_client):
+async def test_async_codebook_default(async_client):
     codebook = await async_client.codebook(model="multilingual-22-12")
     assert len(codebook) == 96
     assert isinstance(codebook, Codebook)

--- a/tests/sync/test_codebook.py
+++ b/tests/sync/test_codebook.py
@@ -10,15 +10,25 @@ co = cohere.Client(API_KEY)
 
 class TestCodebook(unittest.TestCase):
     def test_success(self):
-        prediction = co.codebook(model="multilingual-22-12", compression_codebook="32x")
-        self.assertEqual(len(prediction.codebook), 96)
-        self.assertIsInstance(prediction.codebook[0], list)
-        self.assertIsInstance(prediction.codebook[1], list)
-        self.assertEqual(len(prediction.codebook[0]), 256)
-        self.assertEqual(len(prediction.codebook[0][0]), 8)
-        self.assertTrue(prediction.meta)
-        self.assertTrue(prediction.meta["api_version"])
-        self.assertTrue(prediction.meta["api_version"]["version"])
+        compression_codebooks = {
+            "32x": (96, 256, 8),
+            "48x": (64, 256, 12),
+            "64x": (48, 256, 16),
+            "96x": (32, 256, 24),
+        }
+        for cb, (segments, num_centroids, length) in compression_codebooks.items():
+            prediction = co.codebook(
+                model="multilingual-22-12",
+                compression_codebook=cb,
+            )
+            self.assertIsInstance(prediction.codebook[0], list)
+            self.assertIsInstance(prediction.codebook[0][0], list)
+            self.assertEqual(len(prediction.codebook), segments)
+            self.assertEqual(len(prediction.codebook[0]), num_centroids)
+            self.assertEqual(len(prediction.codebook[0][0]), length)
+            self.assertTrue(prediction.meta)
+            self.assertTrue(prediction.meta["api_version"])
+            self.assertTrue(prediction.meta["api_version"]["version"])
 
     def test_default_model(self):
         prediction = co.codebook(
@@ -26,4 +36,4 @@ class TestCodebook(unittest.TestCase):
         )
         self.assertEqual(len(prediction.codebook), 96)
         self.assertIsInstance(prediction.codebook[0], list)
-        self.assertIsInstance(prediction.codebook[1], list)
+        self.assertIsInstance(prediction.codebook[0][0], list)

--- a/tests/sync/test_codebook.py
+++ b/tests/sync/test_codebook.py
@@ -23,8 +23,9 @@ class TestCodebook(unittest.TestCase):
         self.assertTrue(prediction.meta["api_version"]["version"])
 
     def test_default_model(self):
-        prediction = co.codebook(model="multilingual-22-12",)
+        prediction = co.codebook(
+            model="multilingual-22-12",
+        )
         self.assertEqual(len(prediction.codebook), 96)
         self.assertIsInstance(prediction.codebook[0], list)
         self.assertIsInstance(prediction.codebook[1], list)
-

--- a/tests/sync/test_codebook.py
+++ b/tests/sync/test_codebook.py
@@ -1,0 +1,30 @@
+import random
+import string
+import unittest
+
+from utils import get_api_key
+
+import cohere
+
+API_KEY = get_api_key()
+co = cohere.Client(API_KEY)
+
+
+class TestCodebook(unittest.TestCase):
+    def test_success(self):
+        prediction = co.codebook(model="multilingual-22-12", compression_codebook="32x")
+        self.assertEqual(len(prediction.codebook), 96)
+        self.assertIsInstance(prediction.codebook[0], list)
+        self.assertIsInstance(prediction.codebook[1], list)
+        self.assertEqual(len(prediction.codebook[0]), 256)
+        self.assertEqual(len(prediction.codebook[1]), 8)
+        self.assertTrue(prediction.meta)
+        self.assertTrue(prediction.meta["api_version"])
+        self.assertTrue(prediction.meta["api_version"]["version"])
+
+    def test_default_model(self):
+        prediction = co.codebook(model="multilingual-22-12",)
+        self.assertEqual(len(prediction.codebook), 96)
+        self.assertIsInstance(prediction.codebook[0], list)
+        self.assertIsInstance(prediction.codebook[1], list)
+

--- a/tests/sync/test_codebook.py
+++ b/tests/sync/test_codebook.py
@@ -15,7 +15,7 @@ class TestCodebook(unittest.TestCase):
         self.assertIsInstance(prediction.codebook[0], list)
         self.assertIsInstance(prediction.codebook[1], list)
         self.assertEqual(len(prediction.codebook[0]), 256)
-        self.assertEqual(len(prediction.codebook[1]), 8)
+        self.assertEqual(len(prediction.codebook[0][0]), 8)
         self.assertTrue(prediction.meta)
         self.assertTrue(prediction.meta["api_version"])
         self.assertTrue(prediction.meta["api_version"]["version"])

--- a/tests/sync/test_codebook.py
+++ b/tests/sync/test_codebook.py
@@ -11,10 +11,10 @@ co = cohere.Client(API_KEY)
 class TestCodebook(unittest.TestCase):
     def test_success(self):
         compression_codebooks = {
-            "32x": (96, 256, 8),
-            "48x": (64, 256, 12),
-            "64x": (48, 256, 16),
-            "96x": (32, 256, 24),
+            "PQ32x": (96, 256, 8),
+            "PQ48x": (64, 256, 12),
+            "PQ64x": (48, 256, 16),
+            "PQ96x": (32, 256, 24),
         }
         for cb, (segments, num_centroids, length) in compression_codebooks.items():
             prediction = co.codebook(

--- a/tests/sync/test_codebook.py
+++ b/tests/sync/test_codebook.py
@@ -1,5 +1,3 @@
-import random
-import string
 import unittest
 
 from utils import get_api_key


### PR DESCRIPTION
Add co.codebook endpoint for compressed embeddings

```python
import cohere
co = cohere.Client(f"{API_KEY}")
response = co.codebook(
  model='multilingual-22-12',
)
print('Codebook: {}'.format(response.codebook))
```