### PR TITLE
Chat and Cluster - Update params and fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.2.0
 
-- [#]() 
+- [#212](https://github.com/cohere-ai/cohere-python/pull/212) 
   - Deprecate co.chat params
     - `session_id`
     - `persona_name`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - `persona_prompt`
   - Add deprecation warning for Chat attribute
     - Use `text` instead of `reply`
+  - Add support for `generation_id`
 
 ## 4.1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
     - Use `text` instead of `reply`
   - Add support for `generation_id`
 
+## 4.1.8
+
+- [#206](https://github.com/cohere-ai/cohere-python/pull/206)
+    - Update cluster endpoint to use UMAP+HDBSCAN
+    - Remove threshold and add n_neighbors and is_deterministic as params
+
 ## 4.1.6
 
 - [#205](https://github.com/cohere-ai/cohere-python/pull/205)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@
   - Add deprecation warning for Chat attribute
     - Use `text` instead of `reply`
   - Add support for `generation_id`
-
-## 4.1.8
-
 - [#206](https://github.com/cohere-ai/cohere-python/pull/206)
     - Update cluster endpoint to use UMAP+HDBSCAN
     - Remove threshold and add n_neighbors and is_deterministic as params

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     - `persona_name`
     - `persona_prompt`
   - Add deprecation warning for Chat attribute
-    - `Use 'text' instead of 'reply'`
+    - Use `text` instead of `reply`
 
 ## 4.1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.2.0
+
+- [#]() 
+  - Deprecate co.chat params
+    - `session_id`
+    - `persona_name`
+    - `persona_prompt`
+  - Add deprecation warning for Chat attribute
+    - `Use 'text' instead of 'reply'`
+
 ## 4.1.6
 
 - [#205](https://github.com/cohere-ai/cohere-python/pull/205)

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -220,10 +220,6 @@ class Client:
         if chatlog_override is not None:
             self._validate_chatlog_override(chatlog_override)
 
-        logger.warning(
-            "The 'reply' attribute is deprecated and will be removed in a future version of this function. Use 'text' instead.",
-        )
-
         json_body = {
             "query": query,
             "conversation_id": conversation_id,

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -622,7 +622,6 @@ class Client:
     def create_cluster_job(
         self,
         embeddings_url: str,
-        threshold: Optional[float] = None,
         min_cluster_size: Optional[int] = None,
         n_neighbors: Optional[int] = None,
         is_deterministic: Optional[bool] = None,
@@ -631,8 +630,6 @@ class Client:
 
         Args:
             embeddings_url (str): File with embeddings to cluster.
-            threshold (Optional[float], optional): Similarity threshold above which two texts are deemed to belong in
-                the same cluster. Defaults to 0.75.
             min_cluster_size (Optional[int], optional): Minimum number of elements in a cluster. Defaults to 10.
             n_neighbors (Optional[int], optional): Number of nearest neighbors used by UMAP to establish the
                 local structure of the data. Defaults to 15. For more information, please refer to
@@ -646,7 +643,6 @@ class Client:
 
         json_body = {
             "embeddings_url": embeddings_url,
-            "threshold": threshold,
             "min_cluster_size": min_cluster_size,
             "n_neighbors": n_neighbors,
             "is_deterministic": is_deterministic,

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -155,15 +155,12 @@ class Client:
     def chat(
         self,
         query: str,
-        session_id: str = "",
         conversation_id: str = "",
         model: Optional[str] = None,
         return_chatlog: bool = False,
         return_prompt: bool = False,
         return_preamble: bool = False,
         chatlog_override: List[Dict[str, str]] = None,
-        persona_name: str = None,
-        persona_prompt: str = None,
         preamble_override: str = None,
         user_name: str = None,
         temperature: float = 0.8,
@@ -174,17 +171,14 @@ class Client:
 
         Args:
             query (str): The query to send to the chatbot.
-            session_id (str): Deprecated, use conversation_id instead.
             conversation_id (str): (Optional) The conversation id to continue the conversation.
             model (str): (Optional) The model to use for generating the next reply.
             return_chatlog (bool): (Optional) Whether to return the chatlog.
             return_prompt (bool): (Optional) Whether to return the prompt.
             return_preamble (bool): (Optional) Whether to return the preamble.
             chatlog_override (List[Dict[str, str]]): (Optional) A list of chatlog entries to override the chatlog.
-            persona_name (str): Deprecated.
-            persona_prompt (str): Deprecated, use preamble_override instead.
             preamble_override (str): (Optional) A string to override the preamble.
-            user_name (str): Deprecated.
+            user_name (str): (Optional) A string to override the username.
             temperature (float): (Optional) The temperature to use for the next reply. The higher the temperature, the more random the reply.
             max_tokens (int): (Optional) The max tokens generated for the next reply.
             stream (bool): Return streaming tokens.
@@ -194,7 +188,7 @@ class Client:
         Examples:
             A simple chat messsage:
                 >>> res = co.chat(query="Hey! How are you doing today?")
-                >>> print(res.reply)
+                >>> print(res.text)
                 >>> print(res.conversation_id)
             Continuing a session using a specific model:
                 >>> res = co.chat(
@@ -202,7 +196,7 @@ class Client:
                 >>>     conversation_id="1234",
                 >>>     model="command-xlarge",
                 >>>     return_chatlog=True)
-                >>> print(res.reply)
+                >>> print(res.text)
                 >>> print(res.chatlog)
             Overriding a chat log:
                 >>> res = co.chat(
@@ -214,7 +208,7 @@ class Client:
                 >>>         {'Bot': 'That is great to hear!'},
                 >>>     ],
                 >>>     return_chatlog=True)
-                >>> print(res.reply)
+                >>> print(res.text)
                 >>> print(res.chatlog)
             Streaming chat:
                 >>> res = co.chat(
@@ -226,24 +220,9 @@ class Client:
         if chatlog_override is not None:
             self._validate_chatlog_override(chatlog_override)
 
-        if session_id != "":
-            conversation_id = session_id
-            logger.warning(
-                "The 'session_id' parameter is deprecated and will be removed in a future version of this function. Use 'conversation_id' instead.",
-            )
-        if persona_prompt is not None:
-            preamble_override = persona_prompt
-            logger.warning(
-                "The 'persona_prompt' parameter is deprecated and will be removed in a future version of this function. Use 'preamble_override' instead.",
-            )
-        if persona_name is not None:
-            logger.warning(
-                "The 'persona_name' parameter is deprecated and will be removed in a future version of this function.",
-            )
-        if user_name is not None:
-            logger.warning(
-                "The 'user_name' parameter is deprecated and will be removed in a future version of this function.",
-            )
+        logger.warning(
+            "The 'reply' attribute is deprecated and will be removed in a future version of this function. Use 'text' instead.",
+        )
 
         json_body = {
             "query": query,
@@ -257,6 +236,7 @@ class Client:
             "temperature": temperature,
             "max_tokens": max_tokens,
             "stream": stream,
+            "user_name": user_name,
         }
         response = self._request(cohere.CHAT_URL, json=json_body, stream=stream)
 

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -186,10 +186,6 @@ class AsyncClient(Client):
         if chatlog_override is not None:
             self._validate_chatlog_override(chatlog_override)
 
-        logger.warning(
-            "The 'reply' attribute is deprecated and will be removed in a future version of this function. Use 'text' instead.",
-        )
-
         json_body = {
             "query": query,
             "conversation_id": conversation_id,

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -171,15 +171,12 @@ class AsyncClient(Client):
     async def chat(
         self,
         query: str,
-        session_id: str = "",
         conversation_id: str = "",
         model: Optional[str] = None,
         return_chatlog: bool = False,
         return_prompt: bool = False,
         return_preamble: bool = False,
         chatlog_override: List[Dict[str, str]] = None,
-        persona_name: str = None,
-        persona_prompt: str = None,
         preamble_override: str = None,
         user_name: str = None,
         temperature: float = 0.8,
@@ -189,24 +186,9 @@ class AsyncClient(Client):
         if chatlog_override is not None:
             self._validate_chatlog_override(chatlog_override)
 
-        if session_id != "":
-            conversation_id = session_id
-            logger.warning(
-                "The 'session_id' parameter is deprecated and will be removed in a future version of this function. Use 'conversation_id' instead.",
-            )
-        if persona_prompt is not None:
-            preamble_override = persona_prompt
-            logger.warning(
-                "The 'persona_prompt' parameter is deprecated and will be removed in a future version of this function. Use 'preamble_override' instead.",
-            )
-        if persona_name is not None:
-            logger.warning(
-                "The 'persona_name' parameter is deprecated and will be removed in a future version of this function.",
-            )
-        if user_name is not None:
-            logger.warning(
-                "The 'user_name' parameter is deprecated and will be removed in a future version of this function.",
-            )
+        logger.warning(
+            "The 'reply' attribute is deprecated and will be removed in a future version of this function. Use 'text' instead.",
+        )
 
         json_body = {
             "query": query,
@@ -220,6 +202,7 @@ class AsyncClient(Client):
             "temperature": temperature,
             "max_tokens": max_tokens,
             "stream": stream,
+            "user_name": user_name,
         }
 
         response = await self._request(cohere.CHAT_URL, json=json_body, stream=stream)

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -385,7 +385,6 @@ class AsyncClient(Client):
     async def create_cluster_job(
         self,
         embeddings_url: str,
-        threshold: Optional[float] = None,
         min_cluster_size: Optional[int] = None,
         n_neighbors: Optional[int] = None,
         is_deterministic: Optional[bool] = None,
@@ -394,8 +393,6 @@ class AsyncClient(Client):
 
         Args:
             embeddings_url (str): File with embeddings to cluster.
-            threshold (Optional[float], optional): Similarity threshold above which two texts are deemed to belong in
-                the same cluster. Defaults to 0.75.
             min_cluster_size (Optional[int], optional): Minimum number of elements in a cluster. Defaults to 10.
             n_neighbors (Optional[int], optional): Number of nearest neighbors used by UMAP to establish the
                 local structure of the data. Defaults to 15. For more information, please refer to
@@ -409,7 +406,6 @@ class AsyncClient(Client):
 
         json_body = {
             "embeddings_url": embeddings_url,
-            "threshold": threshold,
             "min_cluster_size": min_cluster_size,
             "n_neighbors": n_neighbors,
             "is_deterministic": is_deterministic,

--- a/cohere/responses/chat.py
+++ b/cohere/responses/chat.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any, Dict, Generator, List, NamedTuple, Optional
 
 import requests
@@ -10,8 +11,8 @@ class Chat(CohereObject):
     def __init__(
         self,
         response_id: str,
+        generation_id: str,
         query: str,
-        reply: str,
         text: str,
         conversation_id: str,
         meta: Optional[Dict[str, Any]] = None,
@@ -22,8 +23,8 @@ class Chat(CohereObject):
     ) -> None:
         super().__init__(**kwargs)
         self.response_id = response_id
+        self.generation_id = generation_id
         self.query = query
-        self.reply = reply
         self.text = text
         self.conversation_id = conversation_id
         self.prompt = prompt  # optional
@@ -36,9 +37,9 @@ class Chat(CohereObject):
         return cls(
             id=response["response_id"],
             response_id=response["response_id"],
+            generation_id=response["generation_id"],
             query=query,
             conversation_id=response["conversation_id"],
-            reply=response["text"],
             text=response["text"],
             prompt=response.get("prompt"),  # optional
             chatlog=response.get("chatlog"),  # optional
@@ -53,6 +54,13 @@ class Chat(CohereObject):
             return_chatlog=self.chatlog is not None,
             return_prompt=self.prompt is not None,
         )
+
+    @property
+    def reply(self) -> str:
+        logging.warning(
+            "The 'reply' attribute is deprecated and will be removed in a future version of this function. Use 'text' instead.",
+        )
+        return self.text
 
 
 class AsyncChat(Chat):

--- a/cohere/responses/chat.py
+++ b/cohere/responses/chat.py
@@ -12,6 +12,7 @@ class Chat(CohereObject):
         response_id: str,
         query: str,
         reply: str,
+        text: str,
         conversation_id: str,
         meta: Optional[Dict[str, Any]] = None,
         prompt: Optional[str] = None,
@@ -23,6 +24,7 @@ class Chat(CohereObject):
         self.response_id = response_id
         self.query = query
         self.reply = reply
+        self.text = text
         self.conversation_id = conversation_id
         self.prompt = prompt  # optional
         self.chatlog = chatlog  # optional
@@ -36,7 +38,8 @@ class Chat(CohereObject):
             response_id=response["response_id"],
             query=query,
             conversation_id=response["conversation_id"],
-            reply=response["reply"],
+            reply=response["text"],
+            text=response["text"],
             prompt=response.get("prompt"),  # optional
             chatlog=response.get("chatlog"),  # optional
             client=client,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.1.7"
+version = "4.2.0"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"

--- a/tests/async/test_async_chat.py
+++ b/tests/async/test_async_chat.py
@@ -8,7 +8,7 @@ async def test_async_multi_replies(async_client):
     assert prediction.chatlog is not None
     for _ in range(num_replies):
         prediction = await prediction.respond("oh that's cool")
-        assert isinstance(prediction.reply, str)
+        assert isinstance(prediction.text, str)
         assert isinstance(prediction.conversation_id, str)
         assert prediction.chatlog is not None
         assert prediction.meta

--- a/tests/async/test_async_cluster.py
+++ b/tests/async/test_async_cluster.py
@@ -17,8 +17,9 @@ IN_CI = os.getenv("CI", "").lower() in ["true", "1"]
 async def test_async_create_cluster_job(async_client: AsyncClient):
     create_res = await async_client.create_cluster_job(
         INPUT_FILE,
-        min_cluster_size=3,
-        threshold=0.5,
+        min_cluster_size=10,
+        n_neighbors=15,
+        is_deterministic=True,
     )
     job = await async_client.get_cluster_job(create_res.job_id)
     start = time.time()
@@ -52,8 +53,9 @@ async def test_async_list_cluster_jobs(async_client: AsyncClient):
 async def test_async_wait_for_cluster_job_succeeds(async_client: AsyncClient):
     create_res = await async_client.create_cluster_job(
         INPUT_FILE,
-        min_cluster_size=3,
-        threshold=0.5,
+        min_cluster_size=10,
+        n_neighbors=15,
+        is_deterministic=True,
     )
 
     job = await async_client.wait_for_cluster_job(create_res.job_id, timeout=60, interval=5)
@@ -64,8 +66,9 @@ async def test_async_wait_for_cluster_job_succeeds(async_client: AsyncClient):
 async def test_async_wait_for_cluster_job_times_out(async_client: AsyncClient):
     create_res = await async_client.create_cluster_job(
         INPUT_FILE,
-        min_cluster_size=3,
-        threshold=0.5,
+        min_cluster_size=10,
+        n_neighbors=15,
+        is_deterministic=True,
     )
 
     with pytest.raises(TimeoutError):
@@ -77,8 +80,9 @@ async def test_async_wait_for_cluster_job_times_out(async_client: AsyncClient):
 async def test_async_job_wait_method_succeeds(async_client: AsyncClient):
     create_res = await async_client.create_cluster_job(
         INPUT_FILE,
-        min_cluster_size=3,
-        threshold=0.5,
+        min_cluster_size=10,
+        n_neighbors=15,
+        is_deterministic=True,
     )
 
     job = await create_res.wait(timeout=60, interval=5)
@@ -90,8 +94,9 @@ async def test_async_job_wait_method_succeeds(async_client: AsyncClient):
 async def test_async_job_wait_method_times_out(async_client: AsyncClient):
     create_res = await async_client.create_cluster_job(
         INPUT_FILE,
-        min_cluster_size=3,
-        threshold=0.5,
+        min_cluster_size=10,
+        n_neighbors=15,
+        is_deterministic=True,
     )
 
     with pytest.raises(TimeoutError):

--- a/tests/sync/test_chat.py
+++ b/tests/sync/test_chat.py
@@ -11,7 +11,7 @@ co = cohere.Client(API_KEY)
 class TestChat(unittest.TestCase):
     def test_simple_success(self):
         prediction = co.chat("Yo what up?")
-        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertTrue(prediction.meta)
         self.assertTrue(prediction.meta["api_version"])
@@ -22,12 +22,12 @@ class TestChat(unittest.TestCase):
         prediction = co.chat("Yo what up?")
         for _ in range(num_replies):
             prediction = prediction.respond("oh that's cool")
-            self.assertIsInstance(prediction.reply, str)
+            self.assertIsInstance(prediction.text, str)
             self.assertIsInstance(prediction.conversation_id, str)
 
     def test_valid_model(self):
         prediction = co.chat("Yo what up?", model="medium")
-        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
 
     def test_invalid_model(self):
@@ -36,14 +36,14 @@ class TestChat(unittest.TestCase):
 
     def test_return_chatlog(self):
         prediction = co.chat("Yo what up?", return_chatlog=True)
-        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIsNotNone(prediction.chatlog)
-        self.assertGreaterEqual(len(prediction.chatlog), len(prediction.reply))
+        self.assertGreaterEqual(len(prediction.chatlog), len(prediction.text))
 
     def test_return_chatlog_false(self):
         prediction = co.chat("Yo what up?", return_chatlog=False)
-        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
 
         assert prediction.chatlog is None
@@ -70,7 +70,7 @@ class TestChat(unittest.TestCase):
                 query=query, conversation_id="1234", chatlog_override=chatlog_override, return_chatlog=True
             )
 
-            self.assertIsInstance(prediction.reply, str)
+            self.assertIsInstance(prediction.text, str)
             self.assertIsInstance(prediction.conversation_id, str)
             self.assertIn(expected_chatlog, prediction.chatlog)
 
@@ -92,21 +92,21 @@ class TestChat(unittest.TestCase):
 
     def test_return_prompt(self):
         prediction = co.chat("Yo what up?", return_prompt=True)
-        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIsNotNone(prediction.prompt)
-        self.assertGreaterEqual(len(prediction.prompt), len(prediction.reply))
+        self.assertGreaterEqual(len(prediction.prompt), len(prediction.text))
 
     def test_return_prompt_false(self):
         prediction = co.chat("Yo what up?", return_prompt=False)
-        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         assert prediction.prompt is None
 
     def test_preamble_override(self):
         preamble = "You are a dog who mostly barks"
         prediction = co.chat("Yo what up?", preamble_override=preamble, return_prompt=True)
-        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIn(preamble, prediction.prompt)
 
@@ -120,14 +120,14 @@ class TestChat(unittest.TestCase):
 
         for temperature in temperatures:
             prediction = co.chat("Yo what up?", temperature=temperature, max_tokens=5)
-            self.assertIsInstance(prediction.reply, str)
+            self.assertIsInstance(prediction.text, str)
             self.assertIsInstance(prediction.conversation_id, str)
 
     def test_max_tokens(self):
         prediction = co.chat("Yo what up?", max_tokens=10)
-        self.assertIsInstance(prediction.reply, str)
+        self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
-        tokens = co.tokenize(prediction.reply)
+        tokens = co.tokenize(prediction.text)
         self.assertLessEqual(tokens.length, 10)
 
     def test_stream(self):

--- a/tests/sync/test_cluster.py
+++ b/tests/sync/test_cluster.py
@@ -17,8 +17,9 @@ class TestClient(unittest.TestCase):
         co = self.create_co()
         create_res = co.create_cluster_job(
             VALID_INPUT_FILE,
-            min_cluster_size=3,
-            threshold=0.5,
+            min_cluster_size=10,
+            n_neighbors=15,
+            is_deterministic=True,
         )
         job = co.get_cluster_job(create_res.job_id)
         start = time.time()
@@ -49,8 +50,9 @@ class TestClient(unittest.TestCase):
         co = self.create_co()
         create_res = co.create_cluster_job(
             VALID_INPUT_FILE,
-            min_cluster_size=3,
-            threshold=0.5,
+            min_cluster_size=10,
+            n_neighbors=15,
+            is_deterministic=True,
         )
 
         job = co.wait_for_cluster_job(create_res.job_id, timeout=60, interval=5)
@@ -61,8 +63,9 @@ class TestClient(unittest.TestCase):
         co = self.create_co()
         create_res = co.create_cluster_job(
             VALID_INPUT_FILE,
-            min_cluster_size=3,
-            threshold=0.5,
+            min_cluster_size=10,
+            n_neighbors=15,
+            is_deterministic=True,
         )
 
         def wait():
@@ -75,8 +78,9 @@ class TestClient(unittest.TestCase):
         co = self.create_co()
         create_res = co.create_cluster_job(
             VALID_INPUT_FILE,
-            min_cluster_size=3,
-            threshold=0.5,
+            min_cluster_size=10,
+            n_neighbors=15,
+            is_deterministic=True,
         )
 
         job = create_res.wait(timeout=60, interval=5)
@@ -87,8 +91,9 @@ class TestClient(unittest.TestCase):
         co = self.create_co()
         create_res = co.create_cluster_job(
             VALID_INPUT_FILE,
-            min_cluster_size=3,
-            threshold=0.5,
+            min_cluster_size=10,
+            n_neighbors=15,
+            is_deterministic=True,
         )
 
         def wait():
@@ -101,8 +106,9 @@ class TestClient(unittest.TestCase):
         co = self.create_co()
         create_res = co.create_cluster_job(
             BAD_INPUT_FILE,
-            min_cluster_size=3,
-            threshold=0.5,
+            min_cluster_size=10,
+            n_neighbors=15,
+            is_deterministic=True,
         )
 
         job = create_res.wait(timeout=60, interval=5)


### PR DESCRIPTION
### What this PR does

- Reflects latest endpoint changes
- Deprecates `session_id`
- Deprecates `persona_name`
- Deprecates `persona_prompt`
- Undeprecates `user_name`
- Adds deprecation warning for `reply` (which is now `text`)
- Adds `generation_id`

```
{
    "response_id": "4b41a6fb-aadd-49ba-a967-a3fdd289ad5e",
    "conversation_id": "chat-d489c39a-e152-49da-9ddc-9801bd74d823-1c77d0a5-2b48-4dc3-acc1-000cd79f3d66",
    "generation_id": "1cd867c9-948a-40a4-b6ca-1f64c44879c6",
    "text": "Hey!",
}
```

