### PR TITLE
Chat - add return_preamble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.2.1
+
+- [#214](https://github.com/cohere-ai/cohere-python/pull/214)
+  - Add support for co.Chat parameter:
+    - `return_preamble` 
+
 ## 4.2.0
 
 - [#212](https://github.com/cohere-ai/cohere-python/pull/212) 

--- a/cohere/responses/chat.py
+++ b/cohere/responses/chat.py
@@ -18,6 +18,7 @@ class Chat(CohereObject):
         meta: Optional[Dict[str, Any]] = None,
         prompt: Optional[str] = None,
         chatlog: Optional[List[Dict[str, str]]] = None,
+        preamble: Optional[str] = None,
         client=None,
         **kwargs,
     ) -> None:
@@ -29,6 +30,7 @@ class Chat(CohereObject):
         self.conversation_id = conversation_id
         self.prompt = prompt  # optional
         self.chatlog = chatlog  # optional
+        self.preamble = preamble
         self.client = client
         self.meta = meta
 
@@ -43,6 +45,7 @@ class Chat(CohereObject):
             text=response["text"],
             prompt=response.get("prompt"),  # optional
             chatlog=response.get("chatlog"),  # optional
+            preamble=response.get("preamble"),  # option
             client=client,
             meta=response.get("meta"),
         )
@@ -53,6 +56,7 @@ class Chat(CohereObject):
             conversation_id=self.conversation_id,
             return_chatlog=self.chatlog is not None,
             return_prompt=self.prompt is not None,
+            return_preamble=self.preamble is not None,
         )
 
     @property
@@ -70,6 +74,7 @@ class AsyncChat(Chat):
             conversation_id=self.conversation_id,
             return_chatlog=self.chatlog is not None,
             return_prompt=self.prompt is not None,
+            return_preamble=self.preamble is not None,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.2.0"
+version = "4.2.1"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"

--- a/tests/sync/test_chat.py
+++ b/tests/sync/test_chat.py
@@ -105,10 +105,11 @@ class TestChat(unittest.TestCase):
 
     def test_preamble_override(self):
         preamble = "You are a dog who mostly barks"
-        prediction = co.chat("Yo what up?", preamble_override=preamble, return_prompt=True)
+        prediction = co.chat("Yo what up?", preamble_override=preamble, return_prompt=True, return_preamble=True)
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIn(preamble, prediction.prompt)
+        self.assertEqual(preamble, prediction.preamble)
 
     def test_invalid_preamble_override(self):
         with self.assertRaises(cohere.CohereError) as e:
@@ -147,3 +148,18 @@ class TestChat(unittest.TestCase):
         self.assertIsNotNone(prediction2.response_id)
 
         self.assertNotEqual(prediction1.response_id, prediction2.response_id)
+
+    def test_return_preamble(self):
+        prediction = co.chat("Yo what up?", return_preamble=True, return_prompt=True)
+        self.assertIsInstance(prediction.text, str)
+        self.assertIsInstance(prediction.conversation_id, str)
+        self.assertIsNotNone(prediction.preamble)
+        self.assertIsNotNone(prediction.prompt)
+        self.assertIn(prediction.preamble, prediction.prompt)
+
+    def test_return_preamble_false(self):
+        prediction = co.chat("Yo what up?", return_preamble=False)
+        self.assertIsInstance(prediction.text, str)
+        self.assertIsInstance(prediction.conversation_id, str)
+
+        assert prediction.preamble is None


### PR DESCRIPTION
### What this PR does
- Closes CNV-497
- Adds support for `return_preamble` on co.chat

```
import cohere
co = cohere.Client(f"{API_KEY}")
response = co.chat(
  query="hey", return_preamble=True, preamble_override="You are a chatbot"
)
print(response.preamble)
>>> "You are a chatbot"
```