### PR TITLE
Chat - Update test

### DIFF
--- a/tests/async/test_async_chat.py
+++ b/tests/async/test_async_chat.py
@@ -7,7 +7,9 @@ async def test_async_multi_replies(async_client):
     prediction = await async_client.chat("Yo what's up?", return_chatlog=True)
     assert prediction.chatlog is not None
     for _ in range(num_replies):
-        prediction = await prediction.respond("oh that's cool")
+        prediction = await async_client.chat(
+            "oh that's cool", conversation_id=prediction.conversation_id, return_chatlog=True
+        )
         assert isinstance(prediction.text, str)
         assert isinstance(prediction.conversation_id, str)
         assert prediction.chatlog is not None


### PR DESCRIPTION
- `test_async_multi_replies` has failed a few times both in `blobheart` and `cohere-python` (`KeyError: 'text'` even thought the response should always have the `text` field). Like [here](https://github.com/cohere-ai/blobheart/actions/runs/4863771926/jobs/8672873352) and [here](https://github.com/cohere-ai/cohere-python/actions/runs/4813385703/jobs/8569977594)
- This PR replaces `respond` by a direct call to co.chat to fix python sdk tests failing in main
- I'll take a look at the test again to understand the issue with `respond`