### PR TITLE
Remove chat_history test skip

### DIFF
--- a/tests/sync/test_chat.py
+++ b/tests/sync/test_chat.py
@@ -164,7 +164,6 @@ class TestChat(unittest.TestCase):
 
         assert prediction.preamble is None
 
-    @unittest.skip("broken between deploys")
     def test_chat_history(self):
         prediction = co.chat(
             "Who are you?",
@@ -179,7 +178,7 @@ class TestChat(unittest.TestCase):
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIsNone(prediction.chatlog)
         self.assertIn("User: Hey!", prediction.prompt)
-        self.assertIn("Bot: Hey! How can I help you?", prediction.prompt)
+        self.assertIn("Chatbot: Hey! How can I help you?", prediction.prompt)
 
     def test_invalid_chat_history(self):
         invalid_chat_histories = [

--- a/tests/sync/test_chat.py
+++ b/tests/sync/test_chat.py
@@ -169,7 +169,7 @@ class TestChat(unittest.TestCase):
             "Who are you?",
             chat_history=[
                 {"user_name": "User", "text": "Hey!"},
-                {"user_name": "Chatbot", "text": "Hey! How can I help you?"},
+                {"user_name": "Bot", "text": "Hey! How can I help you?"},
             ],
             return_prompt=True,
             return_chatlog=True,
@@ -178,7 +178,7 @@ class TestChat(unittest.TestCase):
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIsNone(prediction.chatlog)
         self.assertIn("User: Hey!", prediction.prompt)
-        self.assertIn("Chatbot: Hey! How can I help you?", prediction.prompt)
+        self.assertIn("Bot: Hey! How can I help you?", prediction.prompt)
 
     def test_invalid_chat_history(self):
         invalid_chat_histories = [


### PR DESCRIPTION
- After the latest prod deploy, this was fixed so the test could be added back
- The parameters is now synced with the endpoint using `text` instead of `message`