### PR TITLE
Better string representation for DetectLanguageResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## 4.11.0
+## 4.11
 
 - [#245](https://github.com/cohere-ai/cohere-python/pull/245)
   - Add params `p`, `k` and `logit_bias` to chat
+- [#228](https://github.com/cohere-ai/cohere-python/pull/228)
+  - Better string representation for DetectLanguageResponse
 
 ## 4.10.0
 

--- a/cohere/responses/detectlang.py
+++ b/cohere/responses/detectlang.py
@@ -12,7 +12,7 @@ class Language(CohereObject):
         return f'Language<language_code: "{self.language_code}", language_name: "{self.language_name}">'
 
 
-class DetectLanguageResponse:
+class DetectLanguageResponse(CohereObject):
     def __init__(self, results: List[Language], meta: Optional[Dict[str, Any]] = None):
         self.results = results
         self.meta = meta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.9.1"
+version = "4.9.2"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"


### PR DESCRIPTION
**Before** 
```
>>> print(response)
<cohere.responses.detectlang.DetectLanguageResponse object at 0x02307F50>
```
**After**
```
>>> print(response)
cohere.DetectLanguageResponse {
	results: [Language<language_code: "en", language_name: "English">, Language<language_code: "ru", language_name: "Russian">]
	meta: {'api_version': {'version': '1'}}
}
```