### PR TITLE
Add max_tokens to all chat tests

### DIFF
--- a/cohere/responses/chat.py
+++ b/cohere/responses/chat.py
@@ -49,24 +49,26 @@ class Chat(CohereObject):
             meta=response.get("meta"),
         )
 
-    def respond(self, response: str) -> "Chat":
+    def respond(self, response: str, max_tokens: int = None) -> "Chat":
         return self.client.chat(
             query=response,
             conversation_id=self.conversation_id,
             return_chatlog=self.chatlog is not None,
             return_prompt=self.prompt is not None,
             return_preamble=self.preamble is not None,
+            max_tokens=max_tokens,
         )
 
 
 class AsyncChat(Chat):
-    async def respond(self, response: str) -> "AsyncChat":
+    async def respond(self, response: str, max_tokens: int = None) -> "AsyncChat":
         return await self.client.chat(
             query=response,
             conversation_id=self.conversation_id,
             return_chatlog=self.chatlog is not None,
             return_prompt=self.prompt is not None,
             return_preamble=self.preamble is not None,
+            max_tokens=max_tokens,
         )
 
 

--- a/tests/async/test_async_chat.py
+++ b/tests/async/test_async_chat.py
@@ -4,10 +4,10 @@ import pytest
 @pytest.mark.asyncio
 async def test_async_multi_replies(async_client):
     num_replies = 3
-    prediction = await async_client.chat("Yo what's up?", return_chatlog=True)
+    prediction = await async_client.chat("Yo what's up?", return_chatlog=True, max_tokens=5)
     assert prediction.chatlog is not None
     for _ in range(num_replies):
-        prediction = await prediction.respond("oh that's cool")
+        prediction = await prediction.respond("oh that's cool", max_tokens=5)
         assert isinstance(prediction.text, str)
         assert isinstance(prediction.conversation_id, str)
         assert prediction.chatlog is not None

--- a/tests/sync/test_chat.py
+++ b/tests/sync/test_chat.py
@@ -10,7 +10,7 @@ co = cohere.Client(API_KEY)
 
 class TestChat(unittest.TestCase):
     def test_simple_success(self):
-        prediction = co.chat("Yo what up?")
+        prediction = co.chat("Yo what up?", max_tokens=5)
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertTrue(prediction.meta)
@@ -19,14 +19,14 @@ class TestChat(unittest.TestCase):
 
     def test_multi_replies(self):
         num_replies = 3
-        prediction = co.chat("Yo what up?")
+        prediction = co.chat("Yo what up?", max_tokens=5)
         for _ in range(num_replies):
-            prediction = prediction.respond("oh that's cool")
+            prediction = prediction.respond("oh that's cool", max_tokens=5)
             self.assertIsInstance(prediction.text, str)
             self.assertIsInstance(prediction.conversation_id, str)
 
     def test_valid_model(self):
-        prediction = co.chat("Yo what up?", model="medium")
+        prediction = co.chat("Yo what up?", model="medium", max_tokens=5)
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
 
@@ -35,35 +35,37 @@ class TestChat(unittest.TestCase):
             co.chat("Yo what up?", model="NOT_A_VALID_MODEL").text
 
     def test_return_chatlog(self):
-        prediction = co.chat("Yo what up?", return_chatlog=True)
+        prediction = co.chat("Yo what up?", return_chatlog=True, max_tokens=5)
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIsNotNone(prediction.chatlog)
         self.assertGreaterEqual(len(prediction.chatlog), len(prediction.text))
 
     def test_return_chatlog_false(self):
-        prediction = co.chat("Yo what up?", return_chatlog=False)
+        prediction = co.chat("Yo what up?", return_chatlog=False, max_tokens=5)
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
 
         assert prediction.chatlog is None
 
     def test_return_prompt(self):
-        prediction = co.chat("Yo what up?", return_prompt=True)
+        prediction = co.chat("Yo what up?", return_prompt=True, max_tokens=5)
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIsNotNone(prediction.prompt)
         self.assertGreaterEqual(len(prediction.prompt), len(prediction.text))
 
     def test_return_prompt_false(self):
-        prediction = co.chat("Yo what up?", return_prompt=False)
+        prediction = co.chat("Yo what up?", return_prompt=False, max_tokens=5)
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         assert prediction.prompt is None
 
     def test_preamble_override(self):
         preamble = "You are a dog who mostly barks"
-        prediction = co.chat("Yo what up?", preamble_override=preamble, return_prompt=True, return_preamble=True)
+        prediction = co.chat(
+            "Yo what up?", preamble_override=preamble, return_prompt=True, return_preamble=True, max_tokens=5
+        )
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIn(preamble, prediction.prompt)
@@ -92,16 +94,16 @@ class TestChat(unittest.TestCase):
         self.assertIsInstance(prediction.texts, list)
 
     def test_id(self):
-        prediction1 = co.chat("Yo what up?")
+        prediction1 = co.chat("Yo what up?", max_tokens=5)
         self.assertIsNotNone(prediction1.response_id)
 
-        prediction2 = co.chat("hey")
+        prediction2 = co.chat("hey", max_tokens=5)
         self.assertIsNotNone(prediction2.response_id)
 
         self.assertNotEqual(prediction1.response_id, prediction2.response_id)
 
     def test_return_preamble(self):
-        prediction = co.chat("Yo what up?", return_preamble=True, return_prompt=True)
+        prediction = co.chat("Yo what up?", return_preamble=True, return_prompt=True, max_tokens=5)
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
         self.assertIsNotNone(prediction.preamble)
@@ -109,7 +111,7 @@ class TestChat(unittest.TestCase):
         self.assertIn(prediction.preamble, prediction.prompt)
 
     def test_return_preamble_false(self):
-        prediction = co.chat("Yo what up?", return_preamble=False)
+        prediction = co.chat("Yo what up?", return_preamble=False, max_tokens=5)
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
 
@@ -124,6 +126,7 @@ class TestChat(unittest.TestCase):
             ],
             return_prompt=True,
             return_chatlog=True,
+            max_tokens=5,
         )
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)


### PR DESCRIPTION
- Since the endpoint was updated to generate until EOS instead of a fixed amount of tokens, the tests have been taking longer
- Adds max_tokens to all chat tests to decrease the duration
- Closes CNV-618