### PR TITLE
Allow passing headers to the request as part of request_dict object

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -671,6 +671,10 @@ class Client:
             "Content-Type": "application/json",
             "Request-Source": self.request_source,
         }
+        
+        if 'headers' in self.request_dict:
+            headers.update(self.request_dict['headers'])
+            self.request_dict.pop('headers', None)
 
         url = f"{self.api_url}/{self.api_version}/{endpoint}"
         with requests.Session() as session:


### PR DESCRIPTION
We might need to pass extra headers as part of the cohere client as I'm using it behind a proxy and want to pass more headers to my proxy.