### PR TITLE
Chat - Update request params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
-## 4.11.3
+## 4.12.0
 
 - [#248](https://github.com/cohere-ai/cohere-python/pull/248)
   - Add deprecation warning for Chat parameter `query`
+  - Add deprecation warning for Chat `text` in `chat_history`
+  - Deprecate Chat `chatlog_override`
 
 ## 4.11.0
 
 - [#245](https://github.com/cohere-ai/cohere-python/pull/245)
-  - Add params `p`, `k` and `logit_bias` to chat
+  - Add parameters `p`, `k` and `logit_bias` to chat
 - [#228](https://github.com/cohere-ai/cohere-python/pull/228)
   - Better string representation for DetectLanguageResponse
 - [#249](https://github.com/cohere-ai/cohere-python/pull/249)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## 4.12.0
+## 4.12
 
 - [#248](https://github.com/cohere-ai/cohere-python/pull/248)
   - Add deprecation warning for Chat parameter `query`
   - Add deprecation warning for Chat `text` in `chat_history`
   - Deprecate Chat `chatlog_override`
 
-## 4.11.0
+## 4.11
 
 - [#245](https://github.com/cohere-ai/cohere-python/pull/245)
   - Add parameters `p`, `k` and `logit_bias` to chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.11.1
+- [#248](https://github.com/cohere-ai/cohere-python/pull/248)
+  - Add deprecation warning for Chat parameter
+    - Use `message` instead of `query`
+
 ## 4.11.0
 
 - [#245](https://github.com/cohere-ai/cohere-python/pull/245)

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -298,7 +298,7 @@ class Client:
 
         if query is not None:
             logger.warning(
-                "The 'query' parameter is deprecated and will be removed in a future version of this function. "
+                "The chat_history 'text' key is deprecated and will be removed in a future version of this function. "
                 + "Use 'message' instead.",
             )
             message = query

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -288,13 +288,17 @@ class Client:
                 >>> print(res.citations)
         """
         if chat_history is not None:
+            should_warn = True
             for entry in chat_history:
                 if "text" in entry:
+                    entry["message"] = entry["text"]
+
+                if "text" in entry and should_warn:
                     logger.warning(
                         "The 'text' parameter is deprecated and will be removed in a future version of this function. "
                         + "Use 'message' instead.",
                     )
-                    break
+                    should_warn = False
 
         if query is not None:
             logger.warning(

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -208,13 +208,17 @@ class AsyncClient(Client):
         documents: Optional[List[Dict[str, str]]] = None,
     ) -> Union[AsyncChat, StreamingChat]:
         if chat_history is not None:
+            should_warn = True
             for entry in chat_history:
                 if "text" in entry:
+                    entry["message"] = entry["text"]
+
+                if "text" in entry and should_warn:
                     logger.warning(
                         "The 'text' parameter is deprecated and will be removed in a future version of this function. "
                         + "Use 'message' instead.",
                     )
-                    break
+                    should_warn = False
 
         if query is None and message is None:
             raise CohereError("Either 'query' or 'message' must be provided.")

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -183,7 +183,8 @@ class AsyncClient(Client):
 
     async def chat(
         self,
-        query: str,
+        message: Optional[str] = None,
+        query: Optional[str] = None,
         conversation_id: Optional[str] = "",
         model: Optional[str] = None,
         return_chatlog: Optional[bool] = False,
@@ -209,8 +210,18 @@ class AsyncClient(Client):
         if chat_history is not None:
             self._validate_chat_history(chat_history)
 
+        if query is None and message is None:
+            raise CohereError("Either 'query' or 'message' must be provided.")
+
+        if query is not None:
+            logger.warning(
+                "The 'query' parameter is deprecated and will be removed in a future version of this function. "
+                + "Use 'message' instead.",
+            )
+            message = query
+
         json_body = {
-            "query": query,
+            "message": message,
             "conversation_id": conversation_id,
             "model": model,
             "return_chatlog": return_chatlog,
@@ -232,7 +243,7 @@ class AsyncClient(Client):
         if stream:
             return StreamingChat(response)
         else:
-            return AsyncChat.from_dict(response, query=query, client=self)
+            return AsyncChat.from_dict(response, message=message, client=self)
 
     async def embed(
         self,

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -195,7 +195,6 @@ class AsyncClient(Client):
         return_chatlog: Optional[bool] = False,
         return_prompt: Optional[bool] = False,
         return_preamble: Optional[bool] = False,
-        chatlog_override: List[Dict[str, str]] = None,
         chat_history: Optional[List[Dict[str, str]]] = None,
         preamble_override: Optional[str] = None,
         user_name: Optional[str] = None,
@@ -208,14 +207,14 @@ class AsyncClient(Client):
         mode: Optional[Mode] = None,
         documents: Optional[List[Dict[str, str]]] = None,
     ) -> Union[AsyncChat, StreamingChat]:
-        if chatlog_override is not None:
-            logger.warning(
-                "The 'chatlog_override' parameter is deprecated and will be removed in a future version of this function. "
-                + "Use 'chat_history' to keep track of the conversation instead."
-            )
-
         if chat_history is not None:
-            self._validate_chat_history(chat_history)
+            for entry in chat_history:
+                if "text" in entry:
+                    logger.warning(
+                        "The 'text' parameter is deprecated and will be removed in a future version of this function. "
+                        + "Use 'message' instead.",
+                    )
+                    break
 
         if query is None and message is None:
             raise CohereError("Either 'query' or 'message' must be provided.")

--- a/cohere/responses/chat.py
+++ b/cohere/responses/chat.py
@@ -11,7 +11,7 @@ class Chat(CohereObject):
         self,
         response_id: str,
         generation_id: str,
-        query: str,
+        message: str,
         text: str,
         conversation_id: str,
         meta: Optional[Dict[str, Any]] = None,
@@ -25,23 +25,24 @@ class Chat(CohereObject):
         super().__init__(**kwargs)
         self.response_id = response_id
         self.generation_id = generation_id
-        self.query = query
+        self.query = message  # to be deprecated
+        self.message = message
         self.text = text
         self.conversation_id = conversation_id
         self.prompt = prompt  # optional
         self.chatlog = chatlog  # optional
-        self.preamble = preamble
+        self.preamble = preamble  # optional
         self.client = client
         self.token_count = token_count
         self.meta = meta
 
     @classmethod
-    def from_dict(cls, response: Dict[str, Any], query: str, client) -> "Chat":
+    def from_dict(cls, response: Dict[str, Any], message: str, client) -> "Chat":
         return cls(
             id=response["response_id"],
             response_id=response["response_id"],
             generation_id=response["generation_id"],
-            query=query,
+            message=message,
             conversation_id=response["conversation_id"],
             text=response["text"],
             prompt=response.get("prompt"),  # optional
@@ -54,7 +55,7 @@ class Chat(CohereObject):
 
     def respond(self, response: str, max_tokens: int = None) -> "Chat":
         return self.client.chat(
-            query=response,
+            message=response,
             conversation_id=self.conversation_id,
             return_chatlog=self.chatlog is not None,
             return_prompt=self.prompt is not None,
@@ -66,7 +67,7 @@ class Chat(CohereObject):
 class AsyncChat(Chat):
     async def respond(self, response: str, max_tokens: int = None) -> "AsyncChat":
         return await self.client.chat(
-            query=response,
+            message=response,
             conversation_id=self.conversation_id,
             return_chatlog=self.chatlog is not None,
             return_prompt=self.prompt is not None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.11.0"
+version = "4.11.1"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.11.3"
+version = "4.12.0"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"

--- a/tests/async/test_async_chat.py
+++ b/tests/async/test_async_chat.py
@@ -19,7 +19,7 @@ async def test_async_multi_replies(async_client):
 @pytest.mark.asyncio
 async def test_async_chat_stream(async_client):
     res = await async_client.chat(
-        query="wagmi",
+        message="wagmi",
         max_tokens=5,
         stream=True,
     )
@@ -48,13 +48,13 @@ async def test_async_chat_stream(async_client):
 @pytest.mark.asyncio
 async def test_async_id(async_client):
     res1 = await async_client.chat(
-        query="wagmi",
+        message="wagmi",
         max_tokens=5,
     )
     assert isinstance(res1.response_id, str)
 
     res2 = await async_client.chat(
-        query="wagmi",
+        message="wagmi",
         max_tokens=5,
     )
     assert isinstance(res2.response_id, str)

--- a/tests/sync/test_chat.py
+++ b/tests/sync/test_chat.py
@@ -86,7 +86,7 @@ class TestChat(unittest.TestCase):
 
     def test_stream(self):
         prediction = co.chat(
-            query="Yo what up?",
+            message="Yo what up?",
             max_tokens=5,
             stream=True,
         )
@@ -166,7 +166,7 @@ class TestChat(unittest.TestCase):
         for chat_history in invalid_chat_histories:
             with self.assertRaises(cohere.error.CohereError):
                 _ = co.chat(
-                    query="Hey!",
+                    message="Hey!",
                     chat_history=chat_history,
                 )
 

--- a/tests/sync/test_chat.py
+++ b/tests/sync/test_chat.py
@@ -145,8 +145,8 @@ class TestChat(unittest.TestCase):
         prediction = co.chat(
             "Who are you?",
             chat_history=[
-                {"user_name": "User", "text": "Hey!"},
-                {"user_name": "Chatbot", "text": "Hey! How can I help you?"},
+                {"user_name": "User", "message": "Hey!"},
+                {"user_name": "Chatbot", "message": "Hey! How can I help you?"},
             ],
             return_prompt=True,
             return_chatlog=True,


### PR DESCRIPTION
## Description
- Add support for `message`
- Add deprecation warning for `query`
- Add support for `chat_history` `message`
- Add deprecation warning for `chat_history` `text`
- Deprecate `chatlog_override`
- Updates unit tests

## Linear
- Closes CNV-736
- Closes CNV-698
- Closes CNV-705

## Examples
```
>>> co.chat(message="hey")
cohere.Chat {
        id: 36ef1c39-81dc-4625-beaf-55eb364e6fbc
        response_id: 36ef1c39-81dc-4625-beaf-55eb364e6fbc
        generation_id: 284f785e-0f44-4ef8-bfc8-90afc01de37f
        query: hey
        message: hey
        text: Hello! How may I assist you today?
        conversation_id: c2f2d3f7-1c0d-4afd-8f23-63d34b1dcdae
        prompt: None
        chatlog: None
        preamble: None
        client: <cohere.client.Client object at 0x1028bb880>
        token_count: {'prompt_tokens': 63, 'response_tokens': 9, 'total_tokens': 72}
        meta: {'api_version': {'version': '1'}}
}
```

```
>>> co.chat(query="hey")
The 'query' parameter is deprecated and will be removed in a future version of this function. Use 'message' instead.
cohere.Chat {
        id: b9e28a5b-f1eb-4793-9fee-a0d10d2044e3
        response_id: b9e28a5b-f1eb-4793-9fee-a0d10d2044e3
        generation_id: c4255ba2-6fe6-4199-bff6-b33bfc7335b1
        query: hey
        message: hey
        text: Hi! How can I help you today?
        conversation_id: c347f5c7-6bef-46ab-8751-6fb3c099cd75
        prompt: None
        chatlog: None
        preamble: None
        client: <cohere.client.Client object at 0x1028bb880>
        token_count: {'prompt_tokens': 63, 'response_tokens': 9, 'total_tokens': 72}
        meta: {'api_version': {'version': '1'}}
}
```

```
>>> res = co.chat(message="hey", chat_history=[{"user_name": "User", "message": "hey"}])
```

```
>>> res = co.chat(message="hey", chat_history=[{"user_name": "User", "text": "hey"}])
The chat_history 'text' key is deprecated and will be removed in a future version of this function. Use 'message' instead.
```