### PR TITLE
Rename query param in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Catch ClientPayloadError in AsyncClient and convert it to a CohereAPIError
 - [#250](https://github.com/cohere-ai/cohere-python/pull/250)
   - Add support for query generation and documents in chat (non-streaming)
+- [#253](https://github.com/cohere-ai/cohere-python/pull/250)
+  - Add support for query generation and documents in chat (non-streaming)
 
 ## 4.10.0
 
@@ -353,4 +355,3 @@
 
 - [#18](https://github.com/cohere-ai/cohere-python/pull/18) API Updates - Generate Endpoint
   - Add Frequency Penalty, Presence Penalty, Stop Sequences, and Return Likelihoods for Generate
-

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -201,7 +201,7 @@ class Client:
 
     def chat(
         self,
-        query: str,
+        message: str,
         conversation_id: Optional[str] = "",
         model: Optional[str] = None,
         return_chatlog: Optional[bool] = False,
@@ -220,10 +220,10 @@ class Client:
         mode: Optional[Mode] = None,
         documents: Optional[List[Dict[str, str]]] = None,
     ) -> Union[Chat, StreamingChat]:
-        """Returns a Chat object with the query reply.
+        """Returns a Chat object with a reply to the user's message.
 
         Args:
-            query (str): The query to send to the chatbot.
+            message (str): The message to send to the chatbot.
             conversation_id (str): (Optional) The conversation id to continue the conversation.
             model (str): (Optional) The model to use for generating the next reply.
             return_chatlog (bool): (Optional) Whether to return the chatlog.
@@ -249,12 +249,12 @@ class Client:
 
         Examples:
             A simple chat message:
-                >>> res = co.chat(query="Hey! How are you doing today?")
+                >>> res = co.chat(message="Hey! How are you doing today?")
                 >>> print(res.text)
                 >>> print(res.conversation_id)
             Continuing a session using a specific model:
                 >>> res = co.chat(
-                >>>     query="Hey! How are you doing today?",
+                >>>     message="Hey! How are you doing today?",
                 >>>     conversation_id="1234",
                 >>>     model="command",
                 >>>     return_chatlog=True)
@@ -262,13 +262,13 @@ class Client:
                 >>> print(res.chatlog)
             Streaming chat:
                 >>> res = co.chat(
-                >>>     query="Hey! How are you doing today?",
+                >>>     message="Hey! How are you doing today?",
                 >>>     stream=True)
                 >>> for token in res:
                 >>>     print(token)
             Stateless chat with chat history:
                 >>> res = co.chat(
-                >>>     query="Tell me a joke!",
+                >>>     message="Tell me a joke!",
                 >>>     chat_history=[
                 >>>         {'user_name': 'User', text': 'Hey! How are you doing today?'},
                 >>>         {'user_name': 'Bot', text': 'I am doing great! How can I help you?'},
@@ -277,11 +277,11 @@ class Client:
                 >>> print(res.text)
                 >>> print(res.prompt)
             Query generation example:
-                >>> res = co.chat(query="What are the tallest penguins?", mode="search_query_generation")
+                >>> res = co.chat(message="What are the tallest penguins?", mode="search_query_generation")
                 >>> print(res.queries)
                 >>> print(res.is_search_required)
             Augmented generation example:
-                >>> res = co.chat(query="What are the tallest penguins?",
+                >>> res = co.chat(message="What are the tallest penguins?",
                                   mode="augmented_generation",
                                   documents = [{"title":"Tall penguins", "snippet":"Emperor penguins are the tallest", "url":"http://example.com/foo"}])
                 >>> print(res.text)
@@ -297,7 +297,7 @@ class Client:
             self._validate_chat_history(chat_history)
 
         json_body = {
-            "query": query,
+            "message": message,
             "conversation_id": conversation_id,
             "model": model,
             "return_chatlog": return_chatlog,
@@ -320,7 +320,7 @@ class Client:
         if stream:
             return StreamingChat(response)
         else:
-            return Chat.from_dict(response, query=query, client=self)
+            return Chat.from_dict(response, message=message, client=self)
 
     def _validate_chat_history(self, chat_history: List[Dict[str, str]]) -> None:
         if not isinstance(chat_history, list):

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -188,7 +188,7 @@ class AsyncClient(Client):
 
     async def chat(
         self,
-        query: str,
+        message: str,
         conversation_id: Optional[str] = "",
         model: Optional[str] = None,
         return_chatlog: Optional[bool] = False,
@@ -217,7 +217,7 @@ class AsyncClient(Client):
             self._validate_chat_history(chat_history)
 
         json_body = {
-            "query": query,
+            "message": message,
             "conversation_id": conversation_id,
             "model": model,
             "return_chatlog": return_chatlog,
@@ -241,7 +241,7 @@ class AsyncClient(Client):
         if stream:
             return StreamingChat(response)
         else:
-            return AsyncChat.from_dict(response, query=query, client=self)
+            return AsyncChat.from_dict(response, message=message, client=self)
 
     async def embed(
         self,

--- a/cohere/responses/chat.py
+++ b/cohere/responses/chat.py
@@ -18,7 +18,7 @@ class Chat(CohereObject):
         self,
         response_id: Optional[str],
         generation_id: Optional[str],
-        query: Optional[str],
+        message: Optional[str],
         text: Optional[str],
         conversation_id: Optional[str],
         meta: Optional[Dict[str, Any]] = None,
@@ -35,7 +35,7 @@ class Chat(CohereObject):
         super().__init__(**kwargs)
         self.response_id = response_id
         self.generation_id = generation_id
-        self.query = query
+        self.message = message
         self.text = text
         self.conversation_id = conversation_id
         self.prompt = prompt  # optional
@@ -49,12 +49,12 @@ class Chat(CohereObject):
         self.is_search_required = is_search_required
 
     @classmethod
-    def from_dict(cls, response: Dict[str, Any], query: str, client) -> "Chat":
+    def from_dict(cls, response: Dict[str, Any], message: str, client) -> "Chat":
         return cls(
             id=response.get("response_id"),
             response_id=response.get("response_id"),
             generation_id=response.get("generation_id"),
-            query=query,
+            message=message,
             conversation_id=response["conversation_id"],
             text=response.get("text"),
             prompt=response.get("prompt"),  # optional
@@ -70,7 +70,7 @@ class Chat(CohereObject):
 
     def respond(self, response: str, max_tokens: int = None) -> "Chat":
         return self.client.chat(
-            query=response,
+            message=response,
             conversation_id=self.conversation_id,
             return_chatlog=self.chatlog is not None,
             return_prompt=self.prompt is not None,
@@ -82,7 +82,7 @@ class Chat(CohereObject):
 class AsyncChat(Chat):
     async def respond(self, response: str, max_tokens: int = None) -> "AsyncChat":
         return await self.client.chat(
-            query=response,
+            message=response,
             conversation_id=self.conversation_id,
             return_chatlog=self.chatlog is not None,
             return_prompt=self.prompt is not None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.11.3"
+version = "4.11.4"
 description = ""
 authors = ["Cohere"]
 readme = "README.md"

--- a/tests/async/test_async_chat.py
+++ b/tests/async/test_async_chat.py
@@ -56,7 +56,7 @@ async def test_augmented_generation(async_client):
 @pytest.mark.asyncio
 async def test_async_chat_stream(async_client):
     res = await async_client.chat(
-        query="wagmi",
+        message="wagmi",
         max_tokens=5,
         stream=True,
     )
@@ -85,13 +85,13 @@ async def test_async_chat_stream(async_client):
 @pytest.mark.asyncio
 async def test_async_id(async_client):
     res1 = await async_client.chat(
-        query="wagmi",
+        message="wagmi",
         max_tokens=5,
     )
     assert isinstance(res1.response_id, str)
 
     res2 = await async_client.chat(
-        query="wagmi",
+        message="wagmi",
         max_tokens=5,
     )
     assert isinstance(res2.response_id, str)

--- a/tests/sync/test_chat.py
+++ b/tests/sync/test_chat.py
@@ -88,7 +88,7 @@ class TestChat(unittest.TestCase):
 
     def test_stream(self):
         prediction = co.chat(
-            query="Yo what up?",
+            message="Yo what up?",
             max_tokens=5,
             stream=True,
         )
@@ -168,7 +168,7 @@ class TestChat(unittest.TestCase):
         for chat_history in invalid_chat_histories:
             with self.assertRaises(cohere.error.CohereError):
                 _ = co.chat(
-                    query="Hey!",
+                    message="Hey!",
                     chat_history=chat_history,
                 )
 


### PR DESCRIPTION
Rename the `query` param of the Chat API to `message`, to match the change that happened on the API side