### PR TITLE
Fix chatlog test to expect chatlog when the chat history is set

### DIFF
--- a/tests/sync/test_chat.py
+++ b/tests/sync/test_chat.py
@@ -154,7 +154,7 @@ class TestChat(unittest.TestCase):
         )
         self.assertIsInstance(prediction.text, str)
         self.assertIsInstance(prediction.conversation_id, str)
-        self.assertIsNone(prediction.chatlog)
+        self.assertIsNotNone(prediction.chatlog)
         self.assertIn("User: Hey!", prediction.prompt)
         self.assertIn("Chatbot: Hey! How can I help you?", prediction.prompt)
 


### PR DESCRIPTION
We now return the chatlog when chat history is set. 