### PR TITLE
Alexandre/add base model option

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -1009,25 +1009,12 @@ class Client:
         """
         internal_custom_model_type = CUSTOM_MODEL_PRODUCT_MAPPING[model_type]
 
-        # Figuring out base model
-        if internal_custom_model_type in ["GENERATIVE", "CLASSIFICATION"]:
-            assert base_model is None, "base_model has to be None for generative and classification models"
-            internal_base_model = "medium"
-        elif internal_custom_model_type == "RERANK":
-            internal_base_model = base_model or "english"
-            assert internal_base_model in [
-                "english",
-                "multilingual",
-            ], "base_model has to be `english` or `multilingual`"
-        else:
-            raise ValueError(f"Unsupported model_type: {internal_custom_model_type}")
-
         json = {
             "name": name,
             "settings": {
                 "trainFiles": [],
                 "evalFiles": [],
-                "baseModel": internal_base_model,
+                "baseModel": base_model,
                 "finetuneType": internal_custom_model_type,
             },
         }

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -696,6 +696,7 @@ class AsyncClient(Client):
         name: str,
         model_type: CUSTOM_MODEL_TYPE,
         dataset: CustomModelDataset,
+        base_model: Optional[str] = None,
         hyperparameters: Optional[HyperParametersInput] = None,
     ) -> CustomModel:
         """Create a new custom model
@@ -704,6 +705,11 @@ class AsyncClient(Client):
             name (str): name of your custom model, has to be unique across your organization
             model_type (GENERATIVE, CLASSIFY, RERANK): type of custom model
             dataset (InMemoryDataset, CsvDataset, JsonlDataset, TextDataset): A dataset for your training. Consists of a train and optional eval file.
+            base_model (str): base model to use for your custom model.
+                For generative and classify models, `base_model` has to be None (no option available for now)
+                For rerank models, you can choose between `english` and `multilingual`. Defaults to `english` if not specified.
+                    The English model is better for English, while the multilingual model should be picked if a non-negligible part of queries/documents
+                    will be in other languages
             hyperparameters (HyperParametersInput): adjust hyperparameters for your custom model. Only for generative custom models.
         Returns:
             str: the id of the custom model that was created
@@ -726,12 +732,26 @@ class AsyncClient(Client):
 
         """
         internal_custom_model_type = CUSTOM_MODEL_PRODUCT_MAPPING[model_type]
+
+        # Figuring out base model
+        if internal_custom_model_type in ["GENERATIVE", "CLASSIFICATION"]:
+            assert base_model is None, "base_model has to be None for generative and classification models"
+            internal_base_model = "medium"
+        elif internal_custom_model_type == "RERANK":
+            internal_base_model = base_model or "english"
+            assert internal_base_model in [
+                "english",
+                "multilingual",
+            ], "base_model has to be `english` or `multilingual`"
+        else:
+            raise ValueError(f"Unsupported model_type: {internal_custom_model_type}")
+
         json = {
             "name": name,
             "settings": {
                 "trainFiles": [],
                 "evalFiles": [],
-                "baseModel": "medium",
+                "baseModel": internal_base_model,
                 "finetuneType": internal_custom_model_type,
             },
         }

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -733,25 +733,12 @@ class AsyncClient(Client):
         """
         internal_custom_model_type = CUSTOM_MODEL_PRODUCT_MAPPING[model_type]
 
-        # Figuring out base model
-        if internal_custom_model_type in ["GENERATIVE", "CLASSIFICATION"]:
-            assert base_model is None, "base_model has to be None for generative and classification models"
-            internal_base_model = "medium"
-        elif internal_custom_model_type == "RERANK":
-            internal_base_model = base_model or "english"
-            assert internal_base_model in [
-                "english",
-                "multilingual",
-            ], "base_model has to be `english` or `multilingual`"
-        else:
-            raise ValueError(f"Unsupported model_type: {internal_custom_model_type}")
-
         json = {
             "name": name,
             "settings": {
                 "trainFiles": [],
                 "evalFiles": [],
-                "baseModel": internal_base_model,
+                "baseModel": base_model,
                 "finetuneType": internal_custom_model_type,
             },
         }

--- a/cohere/responses/custom_model.py
+++ b/cohere/responses/custom_model.py
@@ -82,6 +82,7 @@ class CustomModel(CohereObject):
         model_type: CUSTOM_MODEL_TYPE,
         created_at: datetime,
         completed_at: Optional[datetime],
+        base_model: Optional[str] = None,
         model_id: Optional[str] = None,
         hyperparameters: Optional[HyperParameters] = None,
     ) -> None:
@@ -92,6 +93,7 @@ class CustomModel(CohereObject):
         self.model_type = model_type
         self.created_at = created_at
         self.completed_at = completed_at
+        self.base_model = base_model
         self.model_id = model_id
         self.hyperparameters = hyperparameters
 
@@ -104,6 +106,7 @@ class CustomModel(CohereObject):
             model_type=REVERSE_CUSTOM_MODEL_PRODUCT_MAPPING[data["settings"]["finetuneType"]],
             created_at=_parse_date(data["created_at"]),
             completed_at=_parse_date(data["completed_at"]) if "completed_at" in data else None,
+            base_model=data["settings"]["baseModel"],
             model_id=data["model"]["route"] if "model" in data else None,
             hyperparameters=HyperParameters.from_response(data["settings"]["hyperparameters"])
             if data["settings"]["hyperparameters"]


### PR DESCRIPTION
Add a new `base_model` option for reranker finetuning to decide which base model to finetune from: `english` or `multilingual`.
 For the other models (which don't have options), make sure that this variable is not filled.