### PR TITLE
Require poetry-core instead of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ Sphinx = "^5.0"
 sphinx-rtd-theme = "^1.2.0"
 
 [build-system]
-requires = ["poetry>=1.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
In [nixpkgs](https://github.com/NixOS/nixpkgs), we build Python packages using [`build`](https://pypa-build.readthedocs.io/en/stable/) instead of poetry, and so we only need to use the more lightweight poetry-core as the PEP 517 build backend.