### PR TITLE
Docs: Format stream parameter like others

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -172,7 +172,7 @@ class Client:
             num_generations (int): (Optional) The number of generations that will be returned, defaults to 1.
             max_tokens (int): (Optional) The number of tokens to predict per generation, defaults to 20.
             temperature (float): (Optional) The degree of randomness in generations from 0.0 to 5.0, lower is less random.
-            truncate (str): (Optional) One of NONE|START|END, defaults to END. How the API handles text longer than the maximum token length.\
+            truncate (str): (Optional) One of NONE|START|END, defaults to END. How the API handles text longer than the maximum token length.
             stream (bool): Return streaming tokens.
         Returns:
             if stream=False: a Generations object


### PR DESCRIPTION
Currently it isn't bolded/given a bullet point because it's treated like part of the previous parameter

![Screenshot 2023-08-28 at 11 45 11 AM](https://github.com/cohere-ai/cohere-python/assets/1757515/1681f20a-58b5-4467-b160-fd145dd956a6)
