### PR TITLE
Remove unneeded max_tokens test case

### DIFF
--- a/tests/async/test_async_generate.py
+++ b/tests/async/test_async_generate.py
@@ -39,9 +39,6 @@ async def test_return_likelihoods_generation(async_client):
 @pytest.mark.asyncio
 async def test_raise_ex(async_client):
     with pytest.raises(CohereAPIError):
-        await async_client.generate(prompt="too long", max_tokens=100000)
-
-    with pytest.raises(CohereAPIError):
         await async_client.batch_generate(
             ["not too long", "way too long even if we support 8 k tokens" * 2000],
             max_tokens=10,


### PR DESCRIPTION
We're making changes to the behaviour of the `max_tokens` parameter in the Generate API endpoint. One of the changes is to no longer throw a validation error when the requested `max_tokens` value is over the context limit. With this change we also need to remove the test case from the SDK.