### PR TITLE
test[chat]: Add tests for chat endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,13 @@ For a full breakdown of endpoints and arguments, please consult the [SDK Docs](h
 | ---------------- | -------------------- |
 | /generate        | co.generate()        |
 | /embed           | co.embed()           |
+| /chat            | co.chat()            |
 | /classify        | co.classify()        |
 | /tokenize        | co.tokenize()        |
 | /detokenize      | co.detokenize()      |
 | /detect-language | co.detect_language() |
+| /summarize       | co.summarize()       |
+| /rerank          | co.rerank()          |
 
 ## Models
 


### PR DESCRIPTION
This PR addresses the following:

## Adding Tests for the Chat endpoint:
| Test Function      | Reason |
| ----------- | ----------- |
| `test_valid_models`     | As per the API documentation [here](https://docs.cohere.com/reference/chat), there are 4 acceptable models, and the test should reflect this.   |
| `test_stream` | Include a check for when the stream ends |
|`test_invalid_too_many_tokens` | Negative path test for when there are too many tokens |
| `test_invalid_with_both_documents_and_connectors` | Negative path test when both connectors + documents are specified in the same request | 

## Updating README
- Updated the README.md file to include the endpoints as per the [API Reference](https://docs.cohere.com/reference)

Happy to discuss any changes/feedback.