### PR TITLE
Update pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/floatingpurr/sync_with_poetry
-  rev: 0.4.0
+  rev: 1.1.0
   hooks:
     - id: sync_with_poetry
 - repo: https://github.com/pycqa/autoflake


### PR DESCRIPTION
Updates one of the pre-commit hooks that we use to apply formatting, which solves an issue we were seeing on CI.

I ran this locally with `pre-commit run --all-files` and it succeeded.