### PR TITLE
add avro as a dataset save format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 4.46
+ - [#376] (https://github.com/cohere-ai/cohere-python/pull/376)
+    - Adds avro to dataset save formats
+
 ## 4.45
 - [#372] (https://github.com/cohere-ai/cohere-python/pull/372)
   - Remove logit_bias parameter from Chat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.45"
+version = "4.46"
 description = "Python SDK for the Cohere API"
 authors = ["Cohere"]
 readme = "README.md"


### PR DESCRIPTION
Adds `save(filepath, 'avro')` which saves the dataset as 1 local avro file (with no codec set)