### PR TITLE
Add raw_prompting param to Generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
+
 ## 4.46
  - [#376] (https://github.com/cohere-ai/cohere-python/pull/376)
-    - Adds avro to dataset save formats
+    - Add `raw_prompting` param for Generate
+
+## 4.46
+ - [#376] (https://github.com/cohere-ai/cohere-python/pull/376)
+    - Add avro to dataset save formats
 
 ## 4.45
 - [#372] (https://github.com/cohere-ai/cohere-python/pull/372)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## 4.46
- - [#376] (https://github.com/cohere-ai/cohere-python/pull/376)
+## 4.47
+ - [#377] (https://github.com/cohere-ai/cohere-python/pull/377)
     - Add `raw_prompting` param for Generate
 
 ## 4.46

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -162,6 +162,7 @@ class Client:
         truncate: Optional[str] = None,
         logit_bias: Dict[int, float] = {},
         stream: bool = False,
+        raw_prompting: bool = False,
     ) -> Union[Generations, StreamingGenerations]:
         """Generate endpoint.
         See https://docs.cohere.ai/reference/generate for advanced arguments
@@ -176,6 +177,7 @@ class Client:
             temperature (float): (Optional) The degree of randomness in generations from 0.0 to 5.0, lower is less random.
             truncate (str): (Optional) One of NONE|START|END, defaults to END. How the API handles text longer than the maximum token length.
             stream (bool): Return streaming tokens.
+            raw_prompting (bool): When enabled, the user's prompt will be sent to the model without any pre-processing.
         Returns:
             if stream=False: a Generations object
             if stream=True: a StreamingGenerations object including:
@@ -219,6 +221,7 @@ class Client:
             "truncate": truncate,
             "logit_bias": logit_bias,
             "stream": stream,
+            "raw_prompting": raw_prompting,
         }
         response = self._request(cohere.GENERATE_URL, json=json_body, stream=stream)
         if stream:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.46"
+version = "4.47"
 description = "Python SDK for the Cohere API"
 authors = ["Cohere"]
 readme = "README.md"


### PR DESCRIPTION
Adds `raw_prompting` param to the Generate API. When set to True, the user's prompt will be sent to the model without any pre-processing.

