### PR TITLE
Remove logit_bias support from generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 4.48
-- [#?] (https://github.com/cohere-ai/cohere-python/pull/?)
+- [#380] (https://github.com/cohere-ai/cohere-python/pull/380)
   - Remove logit_bias parameter from Generate
 
 ## 4.47

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 4.48
+- [#?] (https://github.com/cohere-ai/cohere-python/pull/?)
+  - Remove logit_bias parameter from Generate
+
 ## 4.47
  - [#378] (https://github.com/cohere-ai/cohere-python/pull/378)
     - Adds embedding_types to embed job

--- a/cohere/client.py
+++ b/cohere/client.py
@@ -160,7 +160,6 @@ class Client:
         stop_sequences: Optional[List[str]] = None,
         return_likelihoods: Optional[str] = None,
         truncate: Optional[str] = None,
-        logit_bias: Dict[int, float] = {},
         stream: bool = False,
     ) -> Union[Generations, StreamingGenerations]:
         """Generate endpoint.
@@ -217,7 +216,6 @@ class Client:
             "stop_sequences": stop_sequences,
             "return_likelihoods": return_likelihoods,
             "truncate": truncate,
-            "logit_bias": logit_bias,
             "stream": stream,
         }
         response = self._request(cohere.GENERATE_URL, json=json_body, stream=stream)
@@ -263,7 +261,6 @@ class Client:
             temperature (float): (Optional) The temperature to use for the response. The higher the temperature, the more random the response.
             p (float): (Optional) The nucleus sampling probability.
             k (float): (Optional) The top-k sampling probability.
-            logit_bias (Dict[int, float]): (Optional) A dictionary of logit bias values to use for the next reply.
             max_tokens (int): (Optional) The max tokens generated for the next reply.
 
             return_chat_history (bool): (Optional) Whether to return the chat history.

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -183,7 +183,6 @@ class AsyncClient(Client):
         stop_sequences: Optional[List[str]] = None,
         return_likelihoods: Optional[str] = None,
         truncate: Optional[str] = None,
-        logit_bias: Dict[int, float] = {},
         stream: bool = False,
     ) -> Union[Generations, StreamingGenerations]:
         json_body = {
@@ -202,7 +201,6 @@ class AsyncClient(Client):
             "stop_sequences": stop_sequences,
             "return_likelihoods": return_likelihoods,
             "truncate": truncate,
-            "logit_bias": logit_bias,
             "stream": stream,
         }
         response = await self._request(cohere.GENERATE_URL, json=json_body, stream=stream)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.47"
+version = "4.48"
 description = "Python SDK for the Cohere API"
 authors = ["Cohere"]
 readme = "README.md"

--- a/tests/sync/test_generate.py
+++ b/tests/sync/test_generate.py
@@ -78,12 +78,6 @@ class TestGenerate(unittest.TestCase):
         prediction = co.generate(preset="SDK-PRESET-TEST-t94jfm")
         self.assertIsInstance(prediction.generations[0].text, str)
 
-    def test_logit_bias(self):
-        prediction = co.generate(model="command-light", prompt="co:here", logit_bias={11: -5.5}, max_tokens=1)
-        self.assertIsInstance(prediction.generations[0].text, str)
-        self.assertIsNone(prediction.generations[0].token_likelihoods)
-        self.assertEqual(prediction.return_likelihoods, None)
-
     def test_prompt_vars(self):
         prediction = co.generate(prompt="Hello {{ name }}", prompt_vars={"name": "Aidan"})
         self.assertIsInstance(prediction.generations[0].text, str)


### PR DESCRIPTION
We're removing the logit_bias parameter from future versions of the platform - support will remain for older versions of the SDK.