### PR TITLE
FIX: wrong dataset_id param in create_embed_job

### DIFF
--- a/cohere/client.py
+++ b/cohere/client.py
@@ -1055,7 +1055,7 @@ class Client:
         """
 
         json_body = {
-            "dataset_id": dataset_id,
+            "input_dataset_id": dataset_id,
             "name": name,
             "model": model,
             "truncate": truncate,

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -746,7 +746,7 @@ class AsyncClient(Client):
         """
 
         json_body = {
-            "dataset_id": dataset_id,
+            "input_dataset_id": dataset_id,
             "name": name,
             "model": model,
             "truncate": truncate,


### PR DESCRIPTION
Fixing #379 
The `EmbedJob` constructor takes the field `dataset_id` as `input_dataset_id` which was mistakenly parsed as `database_id`

Thanks 