### PR TITLE
Remove gen ID from ToolCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## 4.57
+- [#400] (https://github.com/cohere-ai/cohere-python/pull/403)
+  - Remove generation_id from ToolCall object
+
 ## 4.56
 - [#400] (https://github.com/cohere-ai/cohere-python/pull/400)
   - Remove unsupported chat parameters

--- a/cohere/responses/chat.py
+++ b/cohere/responses/chat.py
@@ -44,21 +44,18 @@ class ToolCall(CohereObject, dict):
         self,
         name: str,
         parameters: Dict[str, Any],
-        generation_id: str,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.__dict__ = self
         self.name = name
         self.parameters = parameters
-        self.generation_id = generation_id
 
     @classmethod
     def from_dict(cls, tool_call_res: Dict[str, Any]) -> "ToolCall":
         return cls(
             name=tool_call_res.get("name"),
             parameters=tool_call_res.get("parameters"),
-            generation_id=tool_call_res.get("generation_id"),
         )
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.56"
+version = "4.57"
 description = "Python SDK for the Cohere API"
 authors = ["Cohere"]
 readme = "README.md"


### PR DESCRIPTION
Generation ID is returned at the top level of the response, not in the `tool_call` object.