### PR TITLE
Increase buffer in async client when streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 4.57
+- [#409] (https://github.com/cohere-ai/cohere-python/pull/409)
+  - Increase buffer in async client when streaming
+
 ## 4.56
 - [#400] (https://github.com/cohere-ai/cohere-python/pull/400)
   - Remove unsupported chat parameters

--- a/cohere/client_async.py
+++ b/cohere/client_async.py
@@ -16,6 +16,8 @@ except ImportError:
 
 import aiohttp
 import backoff
+
+import cohere
 from cohere.client import Client
 from cohere.custom_model_dataset import CustomModelDataset
 from cohere.error import CohereAPIError, CohereConnectionError, CohereError
@@ -62,8 +64,6 @@ from cohere.responses.custom_model import (
 from cohere.responses.dataset import AsyncDataset, Dataset, DatasetUsage, ParseInfo
 from cohere.responses.embed_job import AsyncEmbedJob
 from cohere.utils import async_wait_for_job, is_api_key_valid, np_json_dumps
-
-import cohere
 
 JSON = Union[Dict, List]
 

--- a/cohere/responses/chat.py
+++ b/cohere/responses/chat.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Union
 
 import requests
+
 from cohere.responses.base import CohereObject
 
 if TYPE_CHECKING:

--- a/cohere/responses/chat.py
+++ b/cohere/responses/chat.py
@@ -1,10 +1,12 @@
 import json
 from enum import Enum
-from typing import Any, Dict, Generator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Union
 
 import requests
-
 from cohere.responses.base import CohereObject
+
+if TYPE_CHECKING:
+    import aiohttp
 
 
 class ToolParameterDefinitionsValue(CohereObject, dict):
@@ -268,7 +270,7 @@ class ChatToolCallsGenerationEvent(StreamResponse):
 
 class StreamingChat(CohereObject):
     def __init__(self, response):
-        self.response = response
+        self.response: "typing.Optional[aiohttp.ClientResponse]" = response
         self.texts = []
         self.response_id = None
         self.conversation_id = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cohere"
-version = "4.56"
+version = "4.57"
 description = "Python SDK for the Cohere API"
 authors = ["Cohere"]
 readme = "README.md"


### PR DESCRIPTION
The library that we use in the async client has a hard size limit to the buffer it uses when parsing responses. During streaming, where we parse until the end of a line of response, the limit is hit when the response is larger.

The fix here is to increase the buffer size up to a value that should be high enough to parse a single line of API response.