### PR TITLE
Add fix for .float

### DIFF
--- a/src/cohere/client.py
+++ b/src/cohere/client.py
@@ -7,6 +7,11 @@ from .environment import ClientEnvironment
 from .utils import wait, async_wait
 import os
 
+from .overrides import run_overrides
+
+run_overrides()
+
+
 # Use NoReturn as Never type for compatibility
 Never = typing.NoReturn
 

--- a/src/cohere/overrides.py
+++ b/src/cohere/overrides.py
@@ -1,0 +1,19 @@
+from . import EmbedByTypeResponseEmbeddings
+
+
+def allow_access_to_aliases(self, name):
+    for field_name, field_info in self.__fields__.items():
+        if field_info.alias == name:
+            return getattr(self, field_name)
+    raise AttributeError(
+        f"'{type(self).__name__}' object has no attribute '{name}'")
+
+
+def run_overrides():
+    """
+        These are overrides to allow us to make changes to generated code without touching the generated files themselves.
+        Should be used judiciously!
+    """
+
+    # Override to allow access to aliases in EmbedByTypeResponseEmbeddings eg embeddings.float rather than embeddings.float_
+    setattr(EmbedByTypeResponseEmbeddings, "__getattr__", allow_access_to_aliases)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,8 +74,14 @@ class TestClient(unittest.TestCase):
         response = co.embed(
             texts=['hello', 'goodbye'],
             model='embed-english-v3.0',
-            input_type="classification"
+            input_type="classification",
+            embedding_types=["float", "int8", "uint8", "binary", "ubinary"]
         )
+
+        if response.response_type == "embeddings_by_type":
+            self.assertIsNotNone(response.embeddings.float)  # type: ignore
+            self.assertIsNotNone(response.embeddings.float_)
+
         print(response)
 
     @unittest.skipIf(os.getenv("CO_API_URL") is not None, "Doesn't work in staging.")


### PR DESCRIPTION
float is a reserved word in mypy so float_ must be used. For those not using mypy this is very confusing because the docs show float.

This changes supports an easier usage for those not using mypy. The intention is:
* mypy/ide users should use `response.embeddings.float_`(ide completions should make this obvious, .float will be somewhat invisible to them)
* other users should be able to use `response.embeddings.float`(they will be looking at docs)

This change is designed to not touch any generated code. It will also not affect type checking or ide completions which is by design.