### PR TITLE
Add support for context manager

### DIFF
--- a/src/cohere/client.py
+++ b/src/cohere/client.py
@@ -89,11 +89,11 @@ class Client(BaseCohere):
 
     # support context manager until Fern upstreams
     # https://linear.app/buildwithfern/issue/FER-1242/expose-a-context-manager-interface-or-the-http-client-easily
-    async def __enter__(self):
+    def __enter__(self):
         return self
 
-    async def __exit__(self, exc_type, exc_value, traceback):
-        await self._client_wrapper.httpx_client.close()
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._client_wrapper.httpx_client.httpx_client.close()
 
     wait = wait
 
@@ -175,7 +175,7 @@ class AsyncClient(AsyncBaseCohere):
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        await self._client_wrapper.httpx_client.aclose()
+        await self._client_wrapper.httpx_client.httpx_client.aclose()
 
     wait = async_wait
 

--- a/src/cohere/client.py
+++ b/src/cohere/client.py
@@ -87,6 +87,14 @@ class Client(BaseCohere):
 
         validate_args(self, "chat", throw_if_stream_is_true)
 
+    # support context manager until Fern upstreams
+    # https://linear.app/buildwithfern/issue/FER-1242/expose-a-context-manager-interface-or-the-http-client-easily
+    async def __enter__(self):
+        return self
+
+    async def __exit__(self, exc_type, exc_value, traceback):
+        await self._client_wrapper.httpx_client.close()
+
     wait = wait
 
     """
@@ -160,6 +168,14 @@ class AsyncClient(AsyncBaseCohere):
         )
 
         validate_args(self, "chat", throw_if_stream_is_true)
+
+    # support context manager until Fern upstreams
+    # https://linear.app/buildwithfern/issue/FER-1242/expose-a-context-manager-interface-or-the-http-client-easily
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self._client_wrapper.httpx_client.aclose()
 
     wait = async_wait
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -19,6 +19,10 @@ class TestClient(unittest.IsolatedAsyncioTestCase):
         cohere.AsyncClient(api_key=None)
         cohere.AsyncClient(None)
 
+    async def test_context_manager(self) -> None:
+        async with cohere.AsyncClient(api_key="xxx") as client:
+            self.assertIsNotNone(client)
+
     async def test_chat(self) -> None:
         chat = await self.co.chat(
             chat_history=[

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,6 +17,10 @@ class TestClient(unittest.TestCase):
         cohere.Client(api_key=None)
         cohere.Client(None)
 
+    def test_context_manager(self) -> None:
+        with cohere.Client(api_key="xxx") as client:
+            self.assertIsNotNone(client)
+
     def test_chat(self) -> None:
         chat = co.chat(
             chat_history=[


### PR DESCRIPTION
support using `with` to ensure httpx is closed correctly. Fern will upstream this so we can revert this once it is supported