### PR TITLE
Add support for batching in .embed(...)

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -8,3 +8,4 @@ LICENSE
 .github/workflows/tests.yml
 src/cohere/utils.py
 src/cohere/overrides.py
+src/cohere/config.py

--- a/src/cohere/config.py
+++ b/src/cohere/config.py
@@ -1,0 +1,1 @@
+embed_batch_size = 96

--- a/src/cohere/utils.py
+++ b/src/cohere/utils.py
@@ -153,7 +153,7 @@ async def async_wait(
     return job
 
 
-def maybe_sum_field(obj: typing.Any, field: str) -> Optional[int]:
+def sum_fields_if_not_none(obj: typing.Any, field: str) -> Optional[int]:
     non_none = [getattr(obj, field) for obj in obj if getattr(obj, field) is not None]
     return sum(non_none) if non_none else None
 
@@ -161,10 +161,10 @@ def maybe_sum_field(obj: typing.Any, field: str) -> Optional[int]:
 def merge_meta_field(metas: typing.List[ApiMeta]) -> ApiMeta:
     api_version = metas[0].api_version
     billed_units = [meta.billed_units for meta in metas]
-    input_tokens = maybe_sum_field(billed_units, "input_tokens")
-    output_tokens = maybe_sum_field(billed_units, "output_tokens")
-    search_units = maybe_sum_field(billed_units, "search_units")
-    classifications = maybe_sum_field(billed_units, "classifications")
+    input_tokens = sum_fields_if_not_none(billed_units, "input_tokens")
+    output_tokens = sum_fields_if_not_none(billed_units, "output_tokens")
+    search_units = sum_fields_if_not_none(billed_units, "search_units")
+    classifications = sum_fields_if_not_none(billed_units, "classifications")
     warnings = {warning for meta in metas if meta.warnings for warning in meta.warnings}
     return ApiMeta(
         api_version=api_version,

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -94,12 +94,12 @@ class TestClient(unittest.IsolatedAsyncioTestCase):
         )
 
         if response.response_type == "embeddings_by_type":
-            self.assertEqual(len(response.texts), 100)
-            self.assertEqual(len(response.embeddings.float_), 100)
-            self.assertEqual(len(response.embeddings.int8), 100)
-            self.assertEqual(len(response.embeddings.uint8), 100)
-            self.assertEqual(len(response.embeddings.binary), 100)
-            self.assertEqual(len(response.embeddings.ubinary), 100)
+            self.assertEqual(len(response.texts or []), 100)
+            self.assertEqual(len(response.embeddings.float_ or []), 100)
+            self.assertEqual(len(response.embeddings.int8 or []), 100)
+            self.assertEqual(len(response.embeddings.uint8 or []), 100)
+            self.assertEqual(len(response.embeddings.binary or []), 100)
+            self.assertEqual(len(response.embeddings.ubinary or []), 100)
         else:
             self.fail("Expected embeddings_by_type response type")
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -84,6 +84,43 @@ class TestClient(unittest.IsolatedAsyncioTestCase):
         )
         print(response)
 
+    async def test_embed_batch_types(self) -> None:
+        # batch more than 96 texts
+        response = await self.co.embed(
+            texts=['hello']*100,
+            model='embed-english-v3.0',
+            input_type="classification",
+            embedding_types=["float", "int8", "uint8", "binary", "ubinary"]
+        )
+
+        if response.response_type == "embeddings_by_type":
+            self.assertEqual(len(response.texts), 100)
+            self.assertEqual(len(response.embeddings.float_), 100)
+            self.assertEqual(len(response.embeddings.int8), 100)
+            self.assertEqual(len(response.embeddings.uint8), 100)
+            self.assertEqual(len(response.embeddings.binary), 100)
+            self.assertEqual(len(response.embeddings.ubinary), 100)
+        else:
+            self.fail("Expected embeddings_by_type response type")
+
+        print(response)
+
+    async def test_embed_batch_v1(self) -> None:
+        # batch more than 96 texts
+        response = await self.co.embed(
+            texts=['hello']*100,
+            model='embed-english-v3.0',
+            input_type="classification",
+        )
+
+        if response.response_type == "embeddings_floats":
+            self.assertEqual(len(response.embeddings), 100)
+        else:
+            self.fail("Expected embeddings_floats response type")
+
+        print(response)
+
+
     @unittest.skipIf(os.getenv("CO_API_URL") is not None, "Doesn't work in staging.")
     async def test_embed_job_crud(self) -> None:
         dataset = await self.co.datasets.create(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -98,12 +98,12 @@ class TestClient(unittest.TestCase):
         )
 
         if response.response_type == "embeddings_by_type":
-            self.assertEqual(len(response.texts), 100)
-            self.assertEqual(len(response.embeddings.float_), 100)
-            self.assertEqual(len(response.embeddings.int8), 100)
-            self.assertEqual(len(response.embeddings.uint8), 100)
-            self.assertEqual(len(response.embeddings.binary), 100)
-            self.assertEqual(len(response.embeddings.ubinary), 100)
+            self.assertEqual(len(response.texts or []), 100)
+            self.assertEqual(len(response.embeddings.float_ or []), 100)
+            self.assertEqual(len(response.embeddings.int8 or []), 100)
+            self.assertEqual(len(response.embeddings.uint8 or []), 100)
+            self.assertEqual(len(response.embeddings.binary or []), 100)
+            self.assertEqual(len(response.embeddings.ubinary or []), 100)
         else:
             self.fail("Expected embeddings_by_type response type")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -88,6 +88,42 @@ class TestClient(unittest.TestCase):
 
         print(response)
 
+    def test_embed_batch_types(self) -> None:
+        # batch more than 96 texts
+        response = co.embed(
+            texts=['hello']*100,
+            model='embed-english-v3.0',
+            input_type="classification",
+            embedding_types=["float", "int8", "uint8", "binary", "ubinary"]
+        )
+
+        if response.response_type == "embeddings_by_type":
+            self.assertEqual(len(response.texts), 100)
+            self.assertEqual(len(response.embeddings.float_), 100)
+            self.assertEqual(len(response.embeddings.int8), 100)
+            self.assertEqual(len(response.embeddings.uint8), 100)
+            self.assertEqual(len(response.embeddings.binary), 100)
+            self.assertEqual(len(response.embeddings.ubinary), 100)
+        else:
+            self.fail("Expected embeddings_by_type response type")
+
+        print(response)
+
+    def test_embed_batch_v1(self) -> None:
+        # batch more than 96 texts
+        response = co.embed(
+            texts=['hello']*100,
+            model='embed-english-v3.0',
+            input_type="classification",
+        )
+
+        if response.response_type == "embeddings_floats":
+            self.assertEqual(len(response.embeddings), 100)
+        else:
+            self.fail("Expected embeddings_floats response type")
+
+        print(response)
+
     @unittest.skipIf(os.getenv("CO_API_URL") is not None, "Doesn't work in staging.")
     def test_embed_job_crud(self) -> None:
         dataset = co.datasets.create(

--- a/tests/test_embed_utils.py
+++ b/tests/test_embed_utils.py
@@ -1,18 +1,14 @@
-import os
 import unittest
 
-import cohere
-
-from cohere import EmbedResponse_EmbeddingsByType, EmbedByTypeResponseEmbeddings, ApiMeta, ApiMetaBilledUnits
+from cohere import EmbedResponse_EmbeddingsByType, EmbedByTypeResponseEmbeddings, ApiMeta, ApiMetaBilledUnits, \
+    ApiMetaApiVersion, EmbedResponse_EmbeddingsFloats
 from cohere.utils import merge_embed_responses
-
-from src.cohere import ApiMetaApiVersion, EmbedResponse_EmbeddingsFloats
 
 ebt_1 = EmbedResponse_EmbeddingsByType(
     response_type="embeddings_by_type",
     id="1",
     embeddings=EmbedByTypeResponseEmbeddings(
-        float_=[[0, 1, 2], [3, 4, 5]],
+        float=[[0, 1, 2], [3, 4, 5]],
         int8=[[0, 1, 2], [3, 4, 5]],
         uint8=[[0, 1, 2], [3, 4, 5]],
         binary=[[0, 1, 2], [3, 4, 5]],
@@ -35,7 +31,7 @@ ebt_2 = EmbedResponse_EmbeddingsByType(
     response_type="embeddings_by_type",
     id="2",
     embeddings=EmbedByTypeResponseEmbeddings(
-        float_=[[7, 8, 9], [10, 11, 12]],
+        float=[[7, 8, 9], [10, 11, 12]],
         int8=[[7, 8, 9], [10, 11, 12]],
         uint8=[[7, 8, 9], [10, 11, 12]],
         binary=[[7, 8, 9], [10, 11, 12]],
@@ -97,12 +93,16 @@ class TestClient(unittest.TestCase):
             ebt_2
         ])
 
-        self.assertEqual(set(resp.meta.warnings), {"test_warning_1", "test_warning_2"})
+
+        if resp.meta is None:
+            raise Exception("this is just for mpy")
+
+        self.assertEqual(set(*resp.meta.warnings), {"test_warning_1", "test_warning_2"})
         self.assertEqual(resp, EmbedResponse_EmbeddingsByType(
             response_type="embeddings_by_type",
             id="1, 2",
             embeddings=EmbedByTypeResponseEmbeddings(
-                float_=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
+                float=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
                 int8=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
                 uint8=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
                 binary=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
@@ -127,7 +127,10 @@ class TestClient(unittest.TestCase):
             ebf_2
         ])
 
-        self.assertEqual(set(resp.meta.warnings), {"test_warning_1", "test_warning_2"})
+        if resp.meta is None:
+            raise Exception("this is just for mpy")
+
+        self.assertEqual(set(*resp.meta.warnings), {"test_warning_1", "test_warning_2"})
         self.assertEqual(resp, EmbedResponse_EmbeddingsFloats(
             response_type="embeddings_floats",
             id="1, 2",

--- a/tests/test_embed_utils.py
+++ b/tests/test_embed_utils.py
@@ -97,7 +97,7 @@ class TestClient(unittest.TestCase):
         if resp.meta is None:
             raise Exception("this is just for mpy")
 
-        self.assertEqual(set(*resp.meta.warnings), {"test_warning_1", "test_warning_2"})
+        self.assertEqual(set(resp.meta.warnings or []), {"test_warning_1", "test_warning_2"})
         self.assertEqual(resp, EmbedResponse_EmbeddingsByType(
             response_type="embeddings_by_type",
             id="1, 2",
@@ -130,7 +130,7 @@ class TestClient(unittest.TestCase):
         if resp.meta is None:
             raise Exception("this is just for mpy")
 
-        self.assertEqual(set(*resp.meta.warnings), {"test_warning_1", "test_warning_2"})
+        self.assertEqual(set(resp.meta.warnings or []), {"test_warning_1", "test_warning_2"})
         self.assertEqual(resp, EmbedResponse_EmbeddingsFloats(
             response_type="embeddings_floats",
             id="1, 2",

--- a/tests/test_embed_utils.py
+++ b/tests/test_embed_utils.py
@@ -1,0 +1,146 @@
+import os
+import unittest
+
+import cohere
+
+from cohere import EmbedResponse_EmbeddingsByType, EmbedByTypeResponseEmbeddings, ApiMeta, ApiMetaBilledUnits
+from cohere.utils import merge_embed_responses
+
+from src.cohere import ApiMetaApiVersion, EmbedResponse_EmbeddingsFloats
+
+ebt_1 = EmbedResponse_EmbeddingsByType(
+    response_type="embeddings_by_type",
+    id="1",
+    embeddings=EmbedByTypeResponseEmbeddings(
+        float_=[[0, 1, 2], [3, 4, 5]],
+        int8=[[0, 1, 2], [3, 4, 5]],
+        uint8=[[0, 1, 2], [3, 4, 5]],
+        binary=[[0, 1, 2], [3, 4, 5]],
+        ubinary=[[0, 1, 2], [3, 4, 5]],
+    ),
+    texts=["hello", "goodbye"],
+    meta=ApiMeta(
+        api_version=ApiMetaApiVersion(version="1"),
+        billed_units=ApiMetaBilledUnits(
+            input_tokens=1,
+            output_tokens=1,
+            search_units=1,
+            classifications=1
+        ),
+        warnings=["test_warning_1"]
+    )
+)
+
+ebt_2 = EmbedResponse_EmbeddingsByType(
+    response_type="embeddings_by_type",
+    id="2",
+    embeddings=EmbedByTypeResponseEmbeddings(
+        float_=[[7, 8, 9], [10, 11, 12]],
+        int8=[[7, 8, 9], [10, 11, 12]],
+        uint8=[[7, 8, 9], [10, 11, 12]],
+        binary=[[7, 8, 9], [10, 11, 12]],
+        ubinary=[[7, 8, 9], [10, 11, 12]],
+    ),
+    texts=["bye", "seeya"],
+    meta=ApiMeta(
+        api_version=ApiMetaApiVersion(version="1"),
+        billed_units=ApiMetaBilledUnits(
+            input_tokens=2,
+            output_tokens=2,
+            search_units=2,
+            classifications=2
+        ),
+        warnings=["test_warning_1", "test_warning_2"]
+    )
+)
+
+ebf_1 = EmbedResponse_EmbeddingsFloats(
+    response_type="embeddings_floats",
+    id="1",
+    texts=["hello", "goodbye"],
+    embeddings=[[0, 1, 2], [3, 4, 5]],
+    meta=ApiMeta(
+        api_version=ApiMetaApiVersion(version="1"),
+        billed_units=ApiMetaBilledUnits(
+            input_tokens=1,
+            output_tokens=1,
+            search_units=1,
+            classifications=1
+        ),
+        warnings=["test_warning_1"]
+    )
+)
+
+ebf_2 = EmbedResponse_EmbeddingsFloats(
+    response_type="embeddings_floats",
+    id="2",
+    texts=["bye", "seeya"],
+    embeddings=[[7, 8, 9], [10, 11, 12]],
+    meta=ApiMeta(
+        api_version=ApiMetaApiVersion(version="1"),
+        billed_units=ApiMetaBilledUnits(
+            input_tokens=2,
+            output_tokens=2,
+            search_units=2,
+            classifications=2
+        ),
+        warnings=["test_warning_1", "test_warning_2"]
+    )
+)
+
+
+class TestClient(unittest.TestCase):
+
+    def test_merge_embeddings_by_type(self) -> None:
+        resp = merge_embed_responses([
+            ebt_1,
+            ebt_2
+        ])
+
+        self.assertEqual(set(resp.meta.warnings), {"test_warning_1", "test_warning_2"})
+        self.assertEqual(resp, EmbedResponse_EmbeddingsByType(
+            response_type="embeddings_by_type",
+            id="1, 2",
+            embeddings=EmbedByTypeResponseEmbeddings(
+                float_=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
+                int8=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
+                uint8=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
+                binary=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
+                ubinary=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
+            ),
+            texts=["hello", "goodbye", "bye", "seeya"],
+            meta=ApiMeta(
+                api_version=ApiMetaApiVersion(version="1"),
+                billed_units=ApiMetaBilledUnits(
+                    input_tokens=3,
+                    output_tokens=3,
+                    search_units=3,
+                    classifications=3
+                ),
+                warnings=resp.meta.warnings  # order ignored
+            )
+        ))
+
+    def test_merge_embeddings_floats(self) -> None:
+        resp = merge_embed_responses([
+            ebf_1,
+            ebf_2
+        ])
+
+        self.assertEqual(set(resp.meta.warnings), {"test_warning_1", "test_warning_2"})
+        self.assertEqual(resp, EmbedResponse_EmbeddingsFloats(
+            response_type="embeddings_floats",
+            id="1, 2",
+            texts=["hello", "goodbye", "bye", "seeya"],
+            embeddings=[[0, 1, 2], [3, 4, 5], [7, 8, 9], [10, 11, 12]],
+            meta=ApiMeta(
+                api_version=ApiMetaApiVersion(version="1"),
+                billed_units=ApiMetaBilledUnits(
+                    input_tokens=3,
+                    output_tokens=3,
+                    search_units=3,
+                    classifications=3
+                ),
+                warnings=resp.meta.warnings  # order ignored
+            )
+        ))


### PR DESCRIPTION
We manually override embed to allow seamless batching. This still uses autogenerated code but may require manually updating at times