### PR TITLE
Flush stdout in chat_stream example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ use `chat_stream`.
 
 ```Python
 import cohere
+import sys
 
 co = cohere.Client(
     api_key="YOUR_API_KEY",
@@ -67,6 +68,8 @@ stream = co.chat_stream(
 for event in stream:
     if event.event_type == "text-generation":
         print(event.text, end='')
+        # flush stdout to display text immediately rather than buffering by lines
+        sys.stdout.flush()
 ```
 
 ## Contributing


### PR DESCRIPTION
By default, without explicitly flushing stdout, Python only flushes the output buffer when it encounters newlines. This makes it look like generations are only being _returned_ line-by-line. This misunderstanding led me to file [this issue](https://github.com/cohere-ai/cohere-go/issues/72) under the Golang SDK, wrongly thinking that this was an issue with the Cohere SDK as a whole rather than just being a byproduct of Python's output buffering.