### PR TITLE
fix(base_client): max_retries null point exception

### DIFF
--- a/src/cohere/base_client.py
+++ b/src/cohere/base_client.py
@@ -370,7 +370,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         ) as _response:
             if 200 <= _response.status_code < 300:
                 try:
@@ -641,7 +641,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(NonStreamedChatResponse, construct_type(type_=NonStreamedChatResponse, object_=_response.json()))  # type: ignore
@@ -806,7 +806,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         ) as _response:
             if 200 <= _response.status_code < 300:
                 try:
@@ -988,7 +988,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(Generation, construct_type(type_=Generation, object_=_response.json()))  # type: ignore
@@ -1107,7 +1107,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(EmbedResponse, construct_type(type_=EmbedResponse, object_=_response.json()))  # type: ignore
@@ -1217,7 +1217,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(RerankResponse, construct_type(type_=RerankResponse, object_=_response.json()))  # type: ignore
@@ -1347,7 +1347,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(ClassifyResponse, construct_type(type_=ClassifyResponse, object_=_response.json()))  # type: ignore
@@ -1452,7 +1452,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(SummarizeResponse, construct_type(type_=SummarizeResponse, object_=_response.json()))  # type: ignore
@@ -1584,7 +1584,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(DetokenizeResponse, construct_type(type_=DetokenizeResponse, object_=_response.json()))  # type: ignore
@@ -1907,7 +1907,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         ) as _response:
             if 200 <= _response.status_code < 300:
                 try:
@@ -2178,7 +2178,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(NonStreamedChatResponse, construct_type(type_=NonStreamedChatResponse, object_=_response.json()))  # type: ignore
@@ -2343,7 +2343,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         ) as _response:
             if 200 <= _response.status_code < 300:
                 try:
@@ -2525,7 +2525,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(Generation, construct_type(type_=Generation, object_=_response.json()))  # type: ignore
@@ -2644,7 +2644,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(EmbedResponse, construct_type(type_=EmbedResponse, object_=_response.json()))  # type: ignore
@@ -2754,7 +2754,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(RerankResponse, construct_type(type_=RerankResponse, object_=_response.json()))  # type: ignore
@@ -2884,7 +2884,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(ClassifyResponse, construct_type(type_=ClassifyResponse, object_=_response.json()))  # type: ignore
@@ -2989,7 +2989,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(SummarizeResponse, construct_type(type_=SummarizeResponse, object_=_response.json()))  # type: ignore
@@ -3051,7 +3051,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(TokenizeResponse, construct_type(type_=TokenizeResponse, object_=_response.json()))  # type: ignore
@@ -3121,7 +3121,7 @@ class AsyncBaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(DetokenizeResponse, construct_type(type_=DetokenizeResponse, object_=_response.json()))  # type: ignore

--- a/src/cohere/base_client.py
+++ b/src/cohere/base_client.py
@@ -1514,7 +1514,7 @@ class BaseCohere:
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self._client_wrapper.get_timeout(),
             retries=0,
-            max_retries=request_options.get("max_retries") if request_options is not None else 0,  # type: ignore
+            max_retries=request_options.get("max_retries", 0) if request_options is not None else 0,  # type: ignore
         )
         if 200 <= _response.status_code < 300:
             return typing.cast(TokenizeResponse, construct_type(type_=TokenizeResponse, object_=_response.json()))  # type: ignore


### PR DESCRIPTION
Reproduce code(Due to various reasons, the api request failed, such as rate limiting.):

```python
resp = co.tokenize(text=text, model="embed-multilingual-light-v3.0", offline=False)
```

Exception stack trace:

```
response = self.httpx_client.request(*args, **kwargs)
     95 if _should_retry(response=response):
---> 96     if max_retries > retries:
     97         time.sleep(_retry_timeout(response=response, retries=retries))
     98         return self.request(max_retries=max_retries, retries=retries + 1, *args, **kwargs)

TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

The reason is because of `None` value for `max_retries`.

Other similar codes should also have corresponding issues, so I made some modifications together.
