### PR TITLE
Move models param to the endpoint rather than constructor

### DIFF
--- a/src/cohere/bedrock_client.py
+++ b/src/cohere/bedrock_client.py
@@ -17,9 +17,6 @@ class BedrockClient(AwsClient):
             aws_session_token: typing.Optional[str] = None,
             aws_region: typing.Optional[str] = None,
             timeout: typing.Optional[float] = None,
-            chat_model: typing.Optional[str] = None,
-            embed_model: typing.Optional[str] = None,
-            generate_model: typing.Optional[str] = None,
     ):
         AwsClient.__init__(
             self,
@@ -29,7 +26,4 @@ class BedrockClient(AwsClient):
             aws_session_token=aws_session_token,
             aws_region=aws_region,
             timeout=timeout,
-            chat_model=chat_model,
-            embed_model=embed_model,
-            generate_model=generate_model,
         )

--- a/src/cohere/sagemaker_client.py
+++ b/src/cohere/sagemaker_client.py
@@ -14,9 +14,6 @@ class SagemakerClient(AwsClient):
             aws_session_token: typing.Optional[str] = None,
             aws_region: typing.Optional[str] = None,
             timeout: typing.Optional[float] = None,
-            chat_model: typing.Optional[str] = None,
-            embed_model: typing.Optional[str] = None,
-            generate_model: typing.Optional[str] = None,
     ):
         AwsClient.__init__(
             self,
@@ -26,7 +23,4 @@ class SagemakerClient(AwsClient):
             aws_session_token=aws_session_token,
             aws_region=aws_region,
             timeout=timeout,
-            chat_model=chat_model,
-            embed_model=embed_model,
-            generate_model=generate_model,
         )

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+import typing
 import cohere
 from parameterized import parameterized_class  # type: ignore
 
@@ -8,38 +9,50 @@ package_dir = os.path.dirname(os.path.abspath(__file__))
 embed_job = os.path.join(package_dir, 'embed_job.jsonl')
 
 
+models = {
+    "bedrock": {
+        "chat_model": "cohere.command-r-plus-v1:0",
+        "embed_model": "cohere.embed-multilingual-v3",
+        "generate_model": "cohere.command-text-v14",
+    },
+    "sagemaker": {
+        "chat_model": "cohere.command-r-plus-v1:0",
+        "embed_model": "cohere.embed-multilingual-v3",
+        "generate_model": "cohere-command-light",
+    },
+}
+
+
 @parameterized_class([
     {
         "client": cohere.BedrockClient(
             timeout=10000,
             aws_region="us-east-1",
-            chat_model="cohere.command-r-plus-v1:0",
-            embed_model="cohere.embed-multilingual-v3",
-            generate_model="cohere.command-text-v14",
             aws_access_key="...",
             aws_secret_key="...",
             aws_session_token="...",
-        )
+        ),
+        "models": models["bedrock"],
     },
     {
         "client": cohere.SagemakerClient(
             timeout=10000,
             aws_region="us-east-1",
-            chat_model="cohere.command-r-plus-v1:0",
-            embed_model="cohere.embed-multilingual-v3",
-            generate_model="cohere-command-light",
             aws_access_key="...",
             aws_secret_key="...",
             aws_session_token="...",
-        )
+        ),
+        "models": models["sagemaker"],
     }
 ])
 @unittest.skip("skip tests until they work in CI")
 class TestClient(unittest.TestCase):
-    client: cohere.AwsClient;
+    client: cohere.AwsClient
+    models: typing.Dict[str, str]
 
     def test_embed(self) -> None:
         response = self.client.embed(
+            model=self.models["embed_model"],
             texts=["I love Cohere!"],
             input_type="search_document",
         )
@@ -47,12 +60,14 @@ class TestClient(unittest.TestCase):
 
     def test_generate(self) -> None:
         response = self.client.generate(
+            model=self.models["generate_model"],
             prompt='Please explain to me how LLMs work',
         )
         print(response)
 
     def test_generate_stream(self) -> None:
         response = self.client.generate_stream(
+            model=self.models["generate_model"],
             prompt='Please explain to me how LLMs work',
         )
         for event in response:
@@ -62,6 +77,7 @@ class TestClient(unittest.TestCase):
 
     def test_chat(self) -> None:
         response = self.client.chat(
+            model=self.models["chat_model"],
             message='Please explain to me how LLMs work',
         )
         print(response)
@@ -73,6 +89,7 @@ class TestClient(unittest.TestCase):
     def test_chat_stream(self) -> None:
         response_types = set()
         response = self.client.chat_stream(
+            model=self.models["chat_model"],
             message='Please explain to me how LLMs work',
         )
         for event in response:


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR removes the optional `chat_model`, `embed_model`, and `generate_model` parameters from the `__init__` method of the `AwsClient` class and its subclasses `BedrockClient` and `SagemakerClient`. It also updates the test cases in `tests/test_aws_client.py` to use the `models` dictionary instead of hardcoding the model values.

## Summary of Changes
- Removes the optional `chat_model`, `embed_model`, and `generate_model` parameters from the `__init__` method of the `AwsClient` class and its subclasses.
- Updates the test cases in `tests/test_aws_client.py` to use the `models` dictionary for model values instead of hardcoding them.
- Renames the `client` variable to `models` in the `TestClient` class.
- Adds the `models` parameter to the `parameterized_class` decorator in `tests/test_aws_client.py`.

<!-- end-generated-description -->