### PR TITLE
Add rerank support for sagemaker

### DIFF
--- a/src/cohere/aws_client.py
+++ b/src/cohere/aws_client.py
@@ -11,7 +11,7 @@ from httpx import URL, SyncByteStream, ByteStream
 from tokenizers import Tokenizer  # type: ignore
 
 from . import GenerateStreamedResponse, Generation, \
-    NonStreamedChatResponse, EmbedResponse, StreamedChatResponse
+    NonStreamedChatResponse, EmbedResponse, StreamedChatResponse, RerankResponse
 from .client import Client, ClientEnvironment
 from .core import construct_type
 
@@ -97,6 +97,7 @@ response_mapping: typing.Dict[str, typing.Any] = {
     "chat": NonStreamedChatResponse,
     "embed": EmbedResponse,
     "generate": Generation,
+    "rerank": RerankResponse
 }
 
 stream_response_mapping: typing.Dict[str, typing.Any] = {

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -54,8 +54,10 @@ class TestClient(unittest.TestCase):
     client: cohere.AwsClient
     models: typing.Dict[str, str]
 
-    @unittest.skipIf(platform != "sagemaker", "Only sagemaker supports rerank")
     def test_rerank(self) -> None:
+        if self.platform != "sagemaker":
+            self.skipTest("Only sagemaker supports rerank")
+
         docs = [
             'Carson City is the capital city of the American state of Nevada.',
             'The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean. Its capital is Saipan.',

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -9,7 +9,7 @@ package_dir = os.path.dirname(os.path.abspath(__file__))
 embed_job = os.path.join(package_dir, 'embed_job.jsonl')
 
 
-models = {
+model_mapping = {
     "bedrock": {
         "chat_model": "cohere.command-r-plus-v1:0",
         "embed_model": "cohere.embed-multilingual-v3",
@@ -19,6 +19,7 @@ models = {
         "chat_model": "cohere.command-r-plus-v1:0",
         "embed_model": "cohere.embed-multilingual-v3",
         "generate_model": "cohere-command-light",
+        "rerank_model": "rerank",
     },
 }
 
@@ -47,8 +48,22 @@ models = {
 ])
 @unittest.skip("skip tests until they work in CI")
 class TestClient(unittest.TestCase):
-    client: cohere.AwsClient
-    models: typing.Dict[str, str]
+    @unittest.skipIf(platform != "sagemaker", "Only sagemaker supports rerank")
+    def test_rerank(self) -> None:
+        docs = [
+            'Carson City is the capital city of the American state of Nevada.',
+            'The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean. Its capital is Saipan.',
+            'Washington, D.C. (also known as simply Washington or D.C., and officially as the District of Columbia) is the capital of the United States. It is a federal district.',
+            'Capital punishment (the death penalty) has existed in the United States since beforethe United States was a country. As of 2017, capital punishment is legal in 30 of the 50 states.']
+
+        response = self.client.rerank(
+            model=self.models["rerank_model"],
+            query='What is the capital of the United States?',
+            documents=docs,
+            top_n=3,
+        )
+
+        self.assertEqual(len(response.results), 3)
 
     def test_embed(self) -> None:
         response = self.client.embed(

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -26,6 +26,7 @@ model_mapping = {
 
 @parameterized_class([
     {
+        "platform": "bedrock",
         "client": cohere.BedrockClient(
             timeout=10000,
             aws_region="us-east-1",
@@ -36,6 +37,7 @@ model_mapping = {
         "models": models["bedrock"],
     },
     {
+        "platform": "sagemaker",
         "client": cohere.SagemakerClient(
             timeout=10000,
             aws_region="us-east-1",

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -34,7 +34,7 @@ model_mapping = {
             aws_secret_key="...",
             aws_session_token="...",
         ),
-        "models": models["bedrock"],
+        "models": model_mapping["bedrock"],
     },
     {
         "platform": "sagemaker",
@@ -45,7 +45,7 @@ model_mapping = {
             aws_secret_key="...",
             aws_session_token="...",
         ),
-        "models": models["sagemaker"],
+        "models": model_mapping["sagemaker"],
     }
 ])
 @unittest.skip("skip tests until they work in CI")

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -48,6 +48,10 @@ model_mapping = {
 ])
 @unittest.skip("skip tests until they work in CI")
 class TestClient(unittest.TestCase):
+    platform: str
+    client: cohere.AwsClient
+    models: typing.Dict[str, str]
+
     @unittest.skipIf(platform != "sagemaker", "Only sagemaker supports rerank")
     def test_rerank(self) -> None:
         docs = [


### PR DESCRIPTION
<!-- begin-generated-description -->

The PR introduces changes related to adding support for a new `RerankResponse` in the `aws_client.py` module. 

**Summary**
- The `aws_client.py` module now includes support for a new `RerankResponse`.
- This involves updating the import statement to include the `RerankResponse` class and modifying the `stream_response_mapping` dictionary to accommodate the new response type.
- Additionally, the `test_aws_client.py` file has been updated to incorporate testing for the `RerankResponse`.

**Code Changes**
- `aws_client.py`:
- Added `RerankResponse` to the import statement.
- Included `"rerank": RerankResponse` in the `stream_response_mapping` dictionary.
- `test_aws_client.py`:
- Introduced a new test case, `test_rerank`, to validate the functionality of the `RerankResponse`.
- Adjusted the model mapping structure to include a `"rerank_model"` entry.
- Skip the `test_rerank` test case for platforms other than `sagemaker` as only `sagemaker` supports reranking.

<!-- end-generated-description -->