### PR TITLE
Map X-Amzn-Bedrock token counts

### DIFF
--- a/src/cohere/aws_client.py
+++ b/src/cohere/aws_client.py
@@ -150,7 +150,7 @@ def map_response_from_bedrock():
             response_type = response_mapping[endpoint]
             response_obj = json.loads(response.read())
             response_obj["meta"] = map_token_counts(response).dict()
-            cast_obj = typing.cast(response_type,  # type: ignore
+            cast_obj: typing.Any = typing.cast(response_type,  # type: ignore
                                    construct_type(
                                        type_=response_type,
                                        # type: ignore

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -108,10 +108,18 @@ class TestClient(unittest.TestCase):
         self.assertIsNotNone(response.text)
         self.assertIsNotNone(response.generation_id)
         self.assertIsNotNone(response.finish_reason)
-        self.assertIsNotNone(response.meta.tokens.input_tokens)
-        self.assertIsNotNone(response.meta.tokens.input_tokens)
-        self.assertIsNotNone(response.meta.billed_units.input_tokens)
-        self.assertIsNotNone(response.meta.billed_units.input_tokens)
+        
+        self.assertIsNotNone(response.meta)
+        if response.meta is not None:
+            self.assertIsNotNone(response.meta.tokens)
+            if response.meta.tokens is not None:
+                self.assertIsNotNone(response.meta.tokens.input_tokens)
+                self.assertIsNotNone(response.meta.tokens.output_tokens)
+
+            self.assertIsNotNone(response.meta.billed_units)
+            if response.meta.billed_units is not None:
+                self.assertIsNotNone(response.meta.billed_units.input_tokens)
+                self.assertIsNotNone(response.meta.billed_units.input_tokens)
 
     def test_chat_stream(self) -> None:
         response_types = set()

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -108,6 +108,10 @@ class TestClient(unittest.TestCase):
         self.assertIsNotNone(response.text)
         self.assertIsNotNone(response.generation_id)
         self.assertIsNotNone(response.finish_reason)
+        self.assertIsNotNone(response.meta.tokens.input_tokens)
+        self.assertIsNotNone(response.meta.tokens.input_tokens)
+        self.assertIsNotNone(response.meta.billed_units.input_tokens)
+        self.assertIsNotNone(response.meta.billed_units.input_tokens)
 
     def test_chat_stream(self) -> None:
         response_types = set()


### PR DESCRIPTION
<!-- begin-generated-description -->

The PR introduces changes to the `src/cohere/aws_client.py` and `tests/test_aws_client.py` files. 

## Summary
The changes add token and billing information to the responses from the AWS client. Specifically, the `map_token_counts` function is introduced to calculate the input and output token counts from the response headers. This information is then added to the response object under the "meta" field. 

## Changes
- The `ApiMeta`, `ApiMetaTokens`, and `ApiMetaBilledUnits` classes are imported.
- The `map_token_counts` function is added to calculate token counts from response headers.
- The `map_response_from_bedrock` function now adds token count information to the response object.
- The `test_chat` function in `tests/test_aws_client.py` now asserts that the token and billed unit information is not None.

<!-- end-generated-description -->