### PR TITLE
fix(custom code): update decorator to ignore missing arguments

### DIFF
--- a/src/cohere/client.py
+++ b/src/cohere/client.py
@@ -87,7 +87,9 @@ def deprecated_function(fn_name: str) -> typing.Any:
 # `deprecated_kwarg` is the name of the experimental parameter, which can be a dot-separated string for nested parameters
 def experimental_kwarg_decorator(func, deprecated_kwarg):
     # Recursive utility function to check if a kwarg is present in the kwargs.
-    def check_kwarg(deprecated_kwarg: str, kwargs: typing.Dict[str, typing.Any]) -> bool:
+    def check_kwarg(deprecated_kwarg: str, kwargs: typing.Optional[typing.Dict[str, typing.Any]]) -> bool:
+        if kwargs is None:
+            return False
         if "." in deprecated_kwarg:
             key, rest = deprecated_kwarg.split(".", 1)
             if key in kwargs:


### PR DESCRIPTION
Currently, there is a custom decorator that checks to see if deprecated fields are used within function calls
Specifically response_format is checked for schema ([see here](https://github.com/cohere-ai/cohere-python/blob/main/src/cohere/client.py#L163-L164)), this doesn't work if the field is optional, and thus not provided

This works locally when passing in an explicit `None` to `response_format` or leaving it empty, when testing locally