### PR TITLE
Add license to PyPI classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = []
 keywords = []
 
 classifiers = [
+    "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 ]
 
 [project.urls]
-Repository = 'https://github.com/cohere-ai/cohere-python'
+source = "https://github.com/cohere-ai/cohere-python"
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
Adds license to [PyPI project classifiers](https://pypi.org/classifiers/)

The reason that it is very important for this information to be present is that in an enterprise environment, security tools like [Sonatype Nexus IQ](https://help.sonatype.com/iqserver) are used to manage open source software risk. Nexus IQ specifically can be configured to [classify packages according to their license](https://help.sonatype.com/iqserver/managing/policy-management/license-threat-groups). This prevents developers from inadvertently using licenses like [GNU General Public License v2.0](https://www.tldrlegal.com/license/gnu-general-public-license-v2) without realizing that they may be legally obligated to make their entire project open source.

My understanding is that Nexus IQ uses the classifiers panel to determine a project's license.
Because cohere does not currently have a classifiers panel, Nexus cannot determine the license and treats it as a high-risk package.
![image](https://github.com/user-attachments/assets/95e233e1-2fe0-4322-81e4-b56b39625954)


I also slightly modified the project.urls
I don't know why it doesn't currently display on PyPI, possibly the quotation marks, possibly it should be "source" instead of "repository" The [Poetry Docs](https://python-poetry.org/docs/pyproject/) suggest that repository is valid, but I don't see the link on PyPI.

I used NumPy as a model:
https://github.com/numpy/numpy/blob/main/pyproject.toml#L53-L59

```
[project.urls]
homepage = "https://numpy.org"
documentation = "https://numpy.org/doc/"
source = "https://github.com/numpy/numpy"
download = "https://pypi.org/project/numpy/#files"
tracker = "https://github.com/numpy/numpy/issues"
"release notes" = "https://numpy.org/doc/stable/release"
```

![image](https://github.com/user-attachments/assets/d496b30d-99e3-4156-b845-04c55722d340)


