### PR TITLE
Fix sagemaker client

### DIFF
--- a/src/cohere/manually_maintained/cohere_aws/client.py
+++ b/src/cohere/manually_maintained/cohere_aws/client.py
@@ -39,7 +39,8 @@ class Client:
         """
         if not AWS_DEPS_AVAILABLE:
             raise CohereError("AWS dependencies not available. Please install boto3 and sagemaker.")
-        self._client = boto3.client("sagemaker")
+        self._client = boto3.client("sagemaker-runtime", region_name=aws_region)
+        self._service_client = boto3.client("sagemaker", region_name=aws_region)
         if os.environ.get('AWS_DEFAULT_REGION') is None:
             os.environ['AWS_DEFAULT_REGION'] = aws_region
         self._sess = sage.Session(sagemaker_client=self._service_client)

--- a/src/cohere/manually_maintained/cohere_aws/client.py
+++ b/src/cohere/manually_maintained/cohere_aws/client.py
@@ -39,7 +39,7 @@ class Client:
         """
         if not AWS_DEPS_AVAILABLE:
             raise CohereError("AWS dependencies not available. Please install boto3 and sagemaker.")
-        self._client = boto3.client()
+        self._client = boto3.client("sagemaker")
         if os.environ.get('AWS_DEFAULT_REGION') is None:
             os.environ['AWS_DEFAULT_REGION'] = aws_region
         self._sess = sage.Session(sagemaker_client=self._service_client)


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `client.py` file in the `cohere_aws` package. The changes ensure that the AWS client is correctly configured to use the `sagemaker` service.

- The `boto3.client()` call is now passed the `"sagemaker"` argument to specify the service.
- The `os.environ['AWS_DEFAULT_REGION']` is set to the `aws_region` if it is not already set.
- The `sage.Session` is created with the `sagemaker_client` parameter set to the `self._service_client`.

<!-- end-generated-description -->