### PR TITLE
Skip embed job tests

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -127,7 +127,7 @@ class TestClient(unittest.IsolatedAsyncioTestCase):
 
         print(response)
 
-    @unittest.skipIf(os.getenv("CO_API_URL") is not None, "Doesn't work in staging.")
+    @unittest.skip("temp")
     async def test_embed_job_crud(self) -> None:
         dataset = await self.co.datasets.create(
             name="test",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -189,7 +189,7 @@ class TestClient(unittest.TestCase):
 
         print(response)
 
-    @unittest.skipIf(os.getenv("CO_API_URL") is not None, "Doesn't work in staging.")
+    @unittest.skip("temp")
     def test_embed_job_crud(self) -> None:
         dataset = co.datasets.create(
             name="test",


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the `test_embed_job_crud` function in the test_async_client.py and test_client.py files. The function is now skipped with the reason `"temp" instead of the previous condition.

## Changes:
- The `@unittest.skipIf` decorator is replaced with `@unittest.skip`.
- The skip reason is changed from `"Doesn't work in staging." to `"temp".

<!-- end-generated-description -->