### PR TITLE
Make base_url fix stricter

### DIFF
--- a/src/cohere/client.py
+++ b/src/cohere/client.py
@@ -121,7 +121,7 @@ def experimental_kwarg_decorator(func, deprecated_kwarg):
 
 
 def fix_base_url(base_url: typing.Optional[str]) -> typing.Optional[str]:
-    if base_url is not None:
+    if base_url is not None and ("cohere.com" in base_url or "cohere.ai" in base_url):
         return base_url.replace("/v1", "")
     return None
 


### PR DESCRIPTION
Fix #638 

<!-- begin-generated-description -->

This PR introduces a change to the `fix_base_url` function in the `client.py` file. The function now checks if the `base_url` contains either "cohere.com" or "cohere.ai" before replacing "/v1" in the URL.

## Changes:
- The `if` statement in the `fix_base_url` function now includes an additional condition: `and ("cohere.com" in base_url or "cohere.ai" in base_url).
- This additional condition ensures that the function only replaces "/v1" in the URL if the `base_url` contains either "cohere.com" or "cohere.ai".

<!-- end-generated-description -->