### PR TITLE
Return base_url when it is not None

### DIFF
--- a/src/cohere/client.py
+++ b/src/cohere/client.py
@@ -121,8 +121,10 @@ def experimental_kwarg_decorator(func, deprecated_kwarg):
 
 
 def fix_base_url(base_url: typing.Optional[str]) -> typing.Optional[str]:
-    if base_url is not None and ("cohere.com" in base_url or "cohere.ai" in base_url):
-        return base_url.replace("/v1", "")
+    if base_url is not None:
+        if "cohere.com" in base_url or "cohere.ai" in base_url:
+            return base_url.replace("/v1", "")
+        return base_url
     return None
 
 


### PR DESCRIPTION
Fix #638 

This PR fixes a bug in `fix_base_url` which does not return the `base_url` when it's != `cohere.com/cohere.ai`

## Changes:
- Ensure `base_url` is returned when passed
- Ensure `/v1` is swapped with `''` when `base_url` contains `cohere.com` or `cohere.ai`
