### PR TITLE
fix: replace deprecated rerank v2 with rerank v3.5 in tests

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -169,7 +169,7 @@ class TestClient(unittest.IsolatedAsyncioTestCase):
             'Capital punishment (the death penalty) has existed in the United States since beforethe United States was a country. As of 2017, capital punishment is legal in 30 of the 50 states.']
 
         response = await self.co.rerank(
-            model='rerank-english-v2.0',
+            model='rerank-v3.5',
             query='What is the capital of the United States?',
             documents=docs,
             top_n=3,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -206,7 +206,7 @@ class TestClient(unittest.TestCase):
             'Capital punishment (the death penalty) has existed in the United States since beforethe United States was a country. As of 2017, capital punishment is legal in 30 of the 50 states.']
 
         response = co.rerank(
-            model='rerank-english-v2.0',
+            model='rerank-v3.5',
             query='What is the capital of the United States?',
             documents=docs,
             top_n=3,


### PR DESCRIPTION
`rerank-english-v2.0` and `rerank-multilingual-v2.0` have been deprecated so the tests need to be updated to use newer models. 