### PR TITLE
fix: replace 5 bare except clauses with except Exception

### DIFF
--- a/src/cohere/core/pydantic_utilities.py
+++ b/src/cohere/core/pydantic_utilities.py
@@ -566,7 +566,7 @@ def _get_model_fields(model: Type["Model"]) -> Mapping[str, PydanticField]:
 def _get_field_default(field: PydanticField) -> Any:
     try:
         value = field.get_default()  # type: ignore[union-attr]
-    except:
+    except Exception:
         value = field.default
     if IS_PYDANTIC_V2:
         from pydantic_core import PydanticUndefined

--- a/src/cohere/core/unchecked_base_model.py
+++ b/src/cohere/core/unchecked_base_model.py
@@ -231,7 +231,7 @@ def _convert_union_type(type_: typing.Type[typing.Any], object_: typing.Any) -> 
                     for inner_type in get_args(union_type):
                         try:
                             objects_discriminant = getattr(object_, metadata.discriminant)
-                        except:
+                        except Exception:
                             objects_discriminant = object_[metadata.discriminant]
                         if inner_type.__fields__[metadata.discriminant].default == objects_discriminant:
                             return construct_type(object_=object_, type_=inner_type)
@@ -365,7 +365,7 @@ def _get_model_fields(
 def _get_field_default(field: PydanticField) -> typing.Any:
     try:
         value = field.get_default()  # type: ignore # Pydantic < v1.10.15
-    except:
+    except Exception:
         value = field.default
     if IS_PYDANTIC_V2:
         from pydantic_core import PydanticUndefined

--- a/src/cohere/manually_maintained/cohere_aws/client.py
+++ b/src/cohere/manually_maintained/cohere_aws/client.py
@@ -1018,12 +1018,12 @@ class Client:
             raise CohereError("No endpoint connected.")
         try:
             self._service_client.delete_endpoint(EndpointName=self._endpoint_name)
-        except:
+        except Exception:
             print("Endpoint not found, skipping deletion.")
 
         try:
             self._service_client.delete_endpoint_config(EndpointConfigName=self._endpoint_name)
-        except:
+        except Exception:
             print("Endpoint config not found, skipping deletion.")
 
     def close(self) -> None:


### PR DESCRIPTION
## What
Replace 5 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical change that only tightens exception handling and should not affect normal execution paths except to allow interrupts/system-exit to propagate.
> 
> **Overview**
> Replaces several bare `except:` clauses with `except Exception:` across Pydantic utilities/model construction and the AWS SageMaker client.
> 
> This narrows error handling to avoid swallowing `BaseException` types (e.g., `KeyboardInterrupt`/`SystemExit`) while keeping the existing fallback behavior for field defaults, union discriminant extraction, and endpoint deletion best-effort cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0394ca5194013fa3b245e42ea5348fdc025135d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->