### PR TITLE
fix(oci): terminate stream on finishReason — OCI does not send [DONE]

### DIFF
--- a/src/cohere/oci_client.py
+++ b/src/cohere/oci_client.py
@@ -1055,36 +1055,45 @@ def transform_oci_stream_wrapper(
                 final_v1_finish_reason = oci_event.get("finishReason", final_v1_finish_reason)
             yield _emit_v1_event(event)
 
+    stream_finished = False
+
+    def _emit_closing_events() -> typing.Iterator[bytes]:
+        """Emit the final closing events for the stream."""
+        if is_v2:
+            if emitted_start:
+                if not emitted_content_end:
+                    yield _emit_v2_event({"type": "content-end", "index": current_content_index})
+                message_end_event: typing.Dict[str, typing.Any] = {
+                    "type": "message-end",
+                    "id": generation_id,
+                    "delta": {"finish_reason": final_finish_reason},
+                }
+                if final_usage:
+                    message_end_event["delta"]["usage"] = final_usage
+                yield _emit_v2_event(message_end_event)
+        else:
+            yield _emit_v1_event(
+                {
+                    "event_type": "stream-end",
+                    "finish_reason": final_v1_finish_reason,
+                    "response": {
+                        "text": full_v1_text,
+                        "generation_id": generation_id,
+                        "finish_reason": final_v1_finish_reason,
+                    },
+                }
+            )
+
     def _process_line(line: str) -> typing.Iterator[bytes]:
+        nonlocal stream_finished
         if not line.startswith("data: "):
             return
 
         data_str = line[6:]
         if data_str.strip() == "[DONE]":
-            if is_v2:
-                if emitted_start:
-                    if not emitted_content_end:
-                        yield _emit_v2_event({"type": "content-end", "index": current_content_index})
-                    message_end_event: typing.Dict[str, typing.Any] = {
-                        "type": "message-end",
-                        "id": generation_id,
-                        "delta": {"finish_reason": final_finish_reason},
-                    }
-                    if final_usage:
-                        message_end_event["delta"]["usage"] = final_usage
-                    yield _emit_v2_event(message_end_event)
-            else:
-                yield _emit_v1_event(
-                    {
-                        "event_type": "stream-end",
-                        "finish_reason": final_v1_finish_reason,
-                        "response": {
-                            "text": full_v1_text,
-                            "generation_id": generation_id,
-                            "finish_reason": final_v1_finish_reason,
-                        },
-                    }
-                )
+            for event_bytes in _emit_closing_events():
+                yield event_bytes
+            stream_finished = True
             return
 
         try:
@@ -1102,6 +1111,12 @@ def transform_oci_stream_wrapper(
         except Exception as exc:
             raise RuntimeError(f"OCI stream event transformation failed for endpoint '{endpoint}': {exc}") from exc
 
+        # OCI may not send [DONE] — treat finishReason as stream termination
+        if "finishReason" in oci_event:
+            for event_bytes in _emit_closing_events():
+                yield event_bytes
+            stream_finished = True
+
     for chunk in stream:
         buffer += chunk
         while b"\n" in buffer:
@@ -1109,8 +1124,10 @@ def transform_oci_stream_wrapper(
             line = line_bytes.decode("utf-8").strip()
             for event_bytes in _process_line(line):
                 yield event_bytes
+            if stream_finished:
+                return
 
-    if buffer.strip():
+    if buffer.strip() and not stream_finished:
         line = buffer.decode("utf-8").strip()
         for event_bytes in _process_line(line):
             yield event_bytes

--- a/tests/test_oci_client.py
+++ b/tests/test_oci_client.py
@@ -113,7 +113,7 @@ class TestOciClient(unittest.TestCase):
         self.assertIn("4", response.text)
 
     def test_chat_stream(self):
-        """Test V1 streaming chat."""
+        """Test V1 streaming chat terminates and produces correct events."""
         events = []
         for event in self.client.chat_stream(
             model="command-r-08-2024",
@@ -124,6 +124,11 @@ class TestOciClient(unittest.TestCase):
         self.assertTrue(len(events) > 0)
         text_events = [e for e in events if hasattr(e, "text") and e.text]
         self.assertTrue(len(text_events) > 0)
+
+        # Verify stream terminates with correct event lifecycle
+        event_types = [getattr(e, "event_type", None) for e in events]
+        self.assertEqual(event_types[0], "stream-start")
+        self.assertEqual(event_types[-1], "stream-end")
 
 
 @unittest.skipIf(os.getenv("TEST_OCI") is None, "TEST_OCI not set")
@@ -186,7 +191,7 @@ class TestOciClientV2(unittest.TestCase):
         self.assertIsNotNone(response.message)
 
     def test_chat_stream_v2(self):
-        """Test streaming chat with v2 client."""
+        """Test V2 streaming chat terminates and produces correct event lifecycle."""
         events = []
         for event in self.client.chat_stream(
             model="command-a-03-2025",
@@ -195,11 +200,16 @@ class TestOciClientV2(unittest.TestCase):
             events.append(event)
 
         self.assertTrue(len(events) > 0)
-        # Verify we received content-delta events with text
-        content_delta_events = [e for e in events if hasattr(e, "type") and e.type == "content-delta"]
-        self.assertTrue(len(content_delta_events) > 0)
 
-        # Verify we can extract text from events
+        # Verify full event lifecycle: message-start → content-start → content-delta(s) → content-end → message-end
+        event_types = [e.type for e in events]
+        self.assertEqual(event_types[0], "message-start")
+        self.assertIn("content-start", event_types)
+        self.assertIn("content-delta", event_types)
+        self.assertIn("content-end", event_types)
+        self.assertEqual(event_types[-1], "message-end")
+
+        # Verify we can extract text from content-delta events
         full_text = ""
         for event in events:
             if (
@@ -214,7 +224,6 @@ class TestOciClientV2(unittest.TestCase):
             ):
                 full_text += event.delta.message.content.text
 
-        # Should have received some text
         self.assertTrue(len(full_text) > 0)
 
 @unittest.skipIf(os.getenv("TEST_OCI") is None, "TEST_OCI not set")


### PR DESCRIPTION
## Summary

Fixes #756 — `OciClient.chat_stream()` and `OciClientV2.chat_stream()` hang indefinitely after receiving all content.

## Root Cause

OCI Generative AI does **not** send a `data: [DONE]` SSE marker to signal end-of-stream. It sends a final event containing `finishReason` and then keeps the HTTP connection open. The SDK's `transform_oci_stream_wrapper` relied on `[DONE]` to emit closing events (`message-end` / `stream-end`) and terminate the generator — so the stream hung forever.

Raw OCI stream behavior:
```
data: {"apiFormat":"COHEREV2","message":{"role":"ASSISTANT","content":[{"type":"TEXT","text":"Hi"}]}}
data: {"apiFormat":"COHEREV2","message":{"role":"ASSISTANT"},"finishReason":"COMPLETE"}
... connection stays open indefinitely, no [DONE] ...
```

## Fix

- When `finishReason` is present in an OCI event, emit closing events and `return` from the generator immediately
- The `[DONE]` code path is preserved as a fallback for forward compatibility
- Extracted closing event emission into `_emit_closing_events()` to avoid duplication between the `[DONE]` and `finishReason` paths

## Verified

**Before (hangs forever):**
```python
for event in client.chat_stream(
    model="command-a-03-2025",
    messages=[{"role": "user", "content": "Count from 1 to 3"}],
):
    print(event.type)

# message-start
# content-start
# content-delta (x6)
# content-end
# ... hangs indefinitely, never reaches message-end
```

**After (terminates correctly):**
```python
for event in client.chat_stream(
    model="command-a-03-2025",
    messages=[{"role": "user", "content": "Count from 1 to 3"}],
):
    print(event.type)

# message-start → content-start → content-delta → content-delta → content-delta →
# content-delta → content-delta → content-delta → content-end → message-end
# Text: 1, 2, 3.
```

## Integration tests strengthened

The existing streaming tests collected events and checked for content, but never asserted the stream **terminated** or verified the **event lifecycle**. Without termination assertions, the tests would have hung forever rather than failing with a clear error.

Updated both V1 and V2 streaming integration tests to assert:

**V1 (`test_chat_stream`):**
- First event is `stream-start`
- Last event is `stream-end`

**V2 (`test_chat_stream_v2`):**
- Full lifecycle: `message-start` → `content-start` → `content-delta`(s) → `content-end` → `message-end`
- First event is `message-start`, last event is `message-end`

```
tests/test_oci_client.py::TestOciClient::test_chat_stream PASSED
tests/test_oci_client.py::TestOciClientV2::test_chat_stream_v2 PASSED
================ 13 passed, 45 deselected, 42 warnings in 1.56s ================
```

## Test plan

- [x] 13/13 streaming tests pass (2 integration + 11 unit)
- [x] V2 streaming terminates with full event lifecycle: `message-start → content-start → content-delta(s) → content-end → message-end`
- [x] V1 streaming terminates with: `stream-start → text-generation(s) → stream-end`
- [x] Non-streaming chat (V1 + V2) unaffected
- [x] Embed unaffected
- [x] Tested against OCI Generative AI us-chicago-1

@daniel-cohere Streaming was broken because OCI doesn't send `[DONE]` — this fixes it by terminating on `finishReason` instead. Also strengthened the integration tests so this class of bug can't hide again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes streaming termination behavior for both V1 and V2 OCI chat streams, which could affect downstream consumers expecting to wait for `[DONE]` or additional events. Scope is contained to stream-wrapping logic and is covered by updated integration assertions.
> 
> **Overview**
> Fixes OCI chat streaming generators hanging when OCI omits the SSE `data: [DONE]` marker by treating any OCI event containing `finishReason` as end-of-stream.
> 
> Refactors stream teardown into a shared `_emit_closing_events()` helper and ensures the wrapper returns immediately after emitting `stream-end` (V1) or `message-end` (V2). Tests now assert correct event lifecycle and termination for both V1 (`stream-start` → `stream-end`) and V2 (`message-start` → `message-end`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d2f5bb5a1d405074232375a113d0a8ed4aebef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->