### PR TITLE
fix(oci): convert image_url to camelCase for OCI vision requests

### DIFF
--- a/src/cohere/oci_client.py
+++ b/src/cohere/oci_client.py
@@ -720,6 +720,9 @@ def transform_request_to_oci(
                         if isinstance(item, dict) and "type" in item:
                             transformed_item = item.copy()
                             transformed_item["type"] = item["type"].upper()
+                            # OCI expects camelCase: image_url → imageUrl
+                            if "image_url" in transformed_item:
+                                transformed_item["imageUrl"] = transformed_item.pop("image_url")
                             transformed_content.append(transformed_item)
                         else:
                             transformed_content.append(item)

--- a/tests/test_oci_client.py
+++ b/tests/test_oci_client.py
@@ -185,6 +185,37 @@ class TestOciClientV2(unittest.TestCase):
         self.assertIsNotNone(response)
         self.assertIsNotNone(response.message)
 
+    def test_chat_vision_v2(self):
+        """Test vision with inline image on Command A Vision."""
+        import base64, struct, zlib
+
+        # Create a minimal 1x1 red PNG
+        raw = b'\x00\xff\x00\x00'
+        compressed = zlib.compress(raw)
+        def chunk(ctype, data):
+            c = ctype + data
+            return struct.pack('>I', len(data)) + c + struct.pack('>I', zlib.crc32(c) & 0xffffffff)
+        ihdr = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
+        png = b'\x89PNG\r\n\x1a\n' + chunk(b'IHDR', ihdr) + chunk(b'IDAT', compressed) + chunk(b'IEND', b'')
+        img_b64 = base64.b64encode(png).decode()
+
+        response = self.client.chat(
+            model="command-a-vision",
+            messages=[{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What color is this image? Reply with one word."},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
+                ],
+            }],
+        )
+
+        self.assertIsNotNone(response)
+        self.assertIsNotNone(response.message)
+        self.assertTrue(len(response.message.content) > 0)
+        # The 1x1 red pixel should be identified as red
+        self.assertIn("red", response.message.content[0].text.lower())
+
     def test_chat_stream_v2(self):
         """Test streaming chat with v2 client."""
         events = []


### PR DESCRIPTION
## Summary

Fixes #760 — `OciClientV2.chat()` with image content returns 400 on Command A Vision.

## Root Cause

OCI Generative AI expects camelCase field names. The SDK already transforms roles (`"user"` → `"USER"`), content types (`"text"` → `"TEXT"`), and tool types (`"function"` → `"FUNCTION"` in #758), but passes `image_url` through as snake_case instead of converting to `imageUrl`.

**SDK sent:**
```json
{"type": "IMAGE_URL", "image_url": {"url": "data:image/png;base64,..."}}
```

**OCI expects:**
```json
{"type": "IMAGE_URL", "imageUrl": {"url": "data:image/png;base64,..."}}
```

## Fix

Convert `image_url` → `imageUrl` in content items during request transformation.

## Verified

```python
response = client.chat(
    model="command-a-vision",
    messages=[{
        "role": "user",
        "content": [
            {"type": "text", "text": "What color is this image? Reply with one word."},
            {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
        ],
    }],
)
# Response: "Red"
```

## Integration test added

`test_chat_vision_v2` sends a 1x1 red PNG to Command A Vision and asserts:
- Response is not None
- Content is non-empty
- Model correctly identifies the color as "red"

```
tests/test_oci_client.py::TestOciClientV2::test_chat_vision_v2 PASSED
================ 46 passed, 13 deselected, 71 warnings in 7.36s ================
```

## Test plan

- [x] 46/46 non-streaming tests pass
- [x] New `test_chat_vision_v2` passes against OCI us-chicago-1 with command-a-vision
- [x] Existing content transformation tests unaffected

@daniel-cohere Vision was broken on OCI because `image_url` wasn't converted to camelCase `imageUrl`. Same pattern as the tool type issue in #758.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized request-shaping change for `OciClientV2.chat()` plus a new integration test; primary risk is limited to OCI vision payload compatibility/regression for message content transformation.
> 
> **Overview**
> Fixes `OciClientV2` chat request transformation to convert vision content items from snake_case `image_url` to OCI-required camelCase `imageUrl`, preventing 400s on Command A Vision.
> 
> Adds an integration test (`test_chat_vision_v2`) that sends a tiny inline PNG via `image_url` content and asserts the model returns a non-empty response that identifies the color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 537b1eb1749703c6af3030454d74d0613f6c8a91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->