### PR TITLE
fix: handle missing content-length header in _get_tokenizer_config_size

### DIFF
--- a/src/cohere/manually_maintained/tokenizers.py
+++ b/src/cohere/manually_maintained/tokenizers.py
@@ -99,4 +99,6 @@ def _get_tokenizer_config_size(tokenizer_url: str) -> float:
         if size:
             break
 
+    if size is None:
+        raise ValueError("No content-length header found (server may use chunked transfer encoding)")
     return round(int(typing.cast(int, size)) / 1024 / 1024, 2)


### PR DESCRIPTION
## Summary

- `_get_tokenizer_config_size` assumes `content-length` or `x-goog-stored-content-length` headers are always present, but servers using chunked transfer encoding omit both, leaving `size` as `None`
- `int(None)` then raises a `TypeError`
- The code comment on line 94 even acknowledged this case but the guard was never added

## Fix

Add an explicit `None` check that raises a `ValueError` before the `int()` cast. Both callers already wrap this function in `try/except Exception` with "Skip the size logging, this is not critical" — the `ValueError` is caught and the tokenizer download proceeds normally.

Closes #762

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple guard in non-critical size-logging code to avoid a `TypeError` when servers omit `Content-Length` headers (e.g., chunked transfer).
> 
> **Overview**
> Prevents `_get_tokenizer_config_size` from calling `int(None)` when tokenizer config HEAD responses omit `Content-Length`/`x-goog-stored-content-length` by explicitly raising a `ValueError`.
> 
> Callers already treat this as best-effort logging, so tokenizer downloads proceed while size logging is skipped when the header is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b1fd1ca0d8e8ef43606d0fdb9a9e8118b1aad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->