### PR TITLE
fix(utils): guard against None fields in merge_embed_responses

### DIFF
--- a/src/cohere/utils.py
+++ b/src/cohere/utils.py
@@ -228,7 +228,7 @@ def merge_embed_responses(responses: typing.List[EmbedResponse]) -> EmbedRespons
             field: [
                 embedding
                 for embedding_by_type in embeddings_by_type
-                for embedding in getattr(embedding_by_type, field)
+                for embedding in (getattr(embedding_by_type, field) or [])
             ]
             for field in fields
         }

--- a/tests/test_embed_utils.py
+++ b/tests/test_embed_utils.py
@@ -189,6 +189,16 @@ class TestClient(unittest.TestCase):
             )
         ))
 
+    def test_merge_embeddings_by_type_with_none_field_in_later_response(self) -> None:
+        resp1 = EmbeddingsByTypeEmbedResponse(
+            response_type="embeddings_by_type", id="1",
+            embeddings=EmbedByTypeResponseEmbeddings(float_=[[1.0, 2.0]]))
+        resp2 = EmbeddingsByTypeEmbedResponse(
+            response_type="embeddings_by_type", id="2",
+            embeddings=EmbedByTypeResponseEmbeddings(float_=None))
+        result = merge_embed_responses([resp1, resp2])
+        self.assertEqual(result.embeddings.float_, [[1.0, 2.0]])  # type: ignore
+
     def test_merge_partial_embeddings_floats(self) -> None:
         resp = merge_embed_responses([
             ebt_partial_1,


### PR DESCRIPTION
## What's broken

When calling `merge_embed_responses` with a list of `EmbeddingsByTypeEmbedResponse` objects, the function determines which embedding fields to collect by inspecting the first response. However, the inner comprehension at line 231 iterates each of those fields over every response without checking for `None`. If any response beyond the first has `None` for a field present in the first response, Python raises `TypeError: 'NoneType' object is not iterable`. This happens in real batching workflows where one batch returns float embeddings and a subsequent batch omits that field.

## Why it happens

The field list is derived from `embeddings_type[0]` only, but later responses with `None` for those fields are iterated unconditionally.

## Fix

Changed the inner comprehension from `for embedding in getattr(embedding_by_type, field)` to `for embedding in (getattr(embedding_by_type, field) or [])`. This treats `None` fields in any response as an empty list, matching the intent of only collecting non-None values.

## Test

Added `test_merge_embeddings_by_type_with_none_field_in_later_response` in `tests/test_embed_utils.py`. It merges two responses where the first has `float_=[[1.0, 2.0]]` and the second has `float_=None`, and asserts the result contains only the embeddings from the first response without raising.

Fixes #770

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in embed response merging plus a test; no auth, security, or API contract changes.
> 
> **Overview**
> Fixes **`merge_embed_responses`** for by-type embed responses when later batched responses omit an embedding field that the first response included.
> 
> The merge loop now treats a **`None`** field on any response as an empty list (`getattr(...) or []`), so merging no longer raises **`TypeError: 'NoneType' object is not iterable`** in mixed batch results.
> 
> Adds a unit test that merges one response with **`float_`** vectors and a second with **`float_=None`**, expecting only the first batch’s embeddings in the output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b264d956191e0dcf1aeee901f34902177f1939ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->