### PR TITLE
fix(utils): guard against None in sum_fields_if_not_none

### DIFF
--- a/src/cohere/utils.py
+++ b/src/cohere/utils.py
@@ -163,7 +163,7 @@ async def async_wait(
 
 
 def sum_fields_if_not_none(obj: typing.Any, field: str) -> Optional[int]:
-    non_none = [getattr(obj, field) for obj in obj if getattr(obj, field) is not None]
+    non_none = [getattr(obj, field) for obj in obj if obj is not None and getattr(obj, field) is not None]
     return sum(non_none) if non_none else None
 
 

--- a/tests/test_embed_utils.py
+++ b/tests/test_embed_utils.py
@@ -2,7 +2,7 @@ import unittest
 
 from cohere import EmbeddingsByTypeEmbedResponse, EmbedByTypeResponseEmbeddings, ApiMeta, ApiMetaBilledUnits, \
     ApiMetaApiVersion, EmbeddingsFloatsEmbedResponse
-from cohere.utils import merge_embed_responses
+from cohere.utils import merge_embed_responses, sum_fields_if_not_none
 
 ebt_1 = EmbeddingsByTypeEmbedResponse(
     response_type="embeddings_by_type",
@@ -188,6 +188,12 @@ class TestClient(unittest.TestCase):
                 warnings=resp.meta.warnings  # order ignored
             )
         ))
+
+    def test_sum_fields_if_not_none_with_none_entries(self) -> None:
+        # billed_units list may contain None when ApiMeta.billed_units is unset;
+        # sum_fields_if_not_none must skip None objects without raising AttributeError
+        result = sum_fields_if_not_none([None, ApiMetaBilledUnits(input_tokens=5), None], "input_tokens")
+        self.assertEqual(result, 5)
 
     def test_merge_partial_embeddings_floats(self) -> None:
         resp = merge_embed_responses([


### PR DESCRIPTION
## What's broken

Calling merge_embed_responses on responses where any ApiMeta has billed_units=None (the default for Optional[ApiMetaBilledUnits]) raises AttributeError. merge_meta_field builds billed_units = [meta.billed_units for meta in metas], which includes None values. sum_fields_if_not_none then iterates that list and calls getattr(obj, field) without first checking if obj is None, crashing with: AttributeError: 'NoneType' object has no attribute 'input_tokens'.

## Why it happens

The list comprehension on line 166 filters on getattr(obj, field) is not None but never checks if obj itself is None before calling getattr on it.

## Fix

Added obj is not None as a leading condition in the list comprehension so None entries are skipped before getattr is attempted. One line changed in src/cohere/utils.py.

## Test

Added test_sum_fields_if_not_none_with_none_entries to tests/test_embed_utils.py. It passes a list containing None entries mixed with a valid ApiMetaBilledUnits object and asserts the function returns the correct sum without raising.

Fixes #772

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in embed response merging with a focused unit test; no auth or API contract changes.
> 
> **Overview**
> Fixes **`merge_embed_responses`** crashing when merged responses include **`ApiMeta`** with unset **`billed_units`**. **`merge_meta_field`** passes a list that can contain **`None`** into **`sum_fields_if_not_none`**, which previously called **`getattr`** on those entries and raised **`AttributeError`**.
> 
> **`sum_fields_if_not_none`** now skips **`None`** list elements before reading token/unit fields. A unit test covers mixed **`None`** and valid **`ApiMetaBilledUnits`** entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8028a23e99c390324c87b91799ac2545379f1677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->