### PR TITLE
fix(unchecked_base_model): handle bare dict in construct_type

### DIFF
--- a/src/cohere/core/unchecked_base_model.py
+++ b/src/cohere/core/unchecked_base_model.py
@@ -360,7 +360,8 @@ def construct_type(
         if not isinstance(object_, typing.Mapping):
             return object_
 
-        key_type, items_type = get_args(type_)
+        args = get_args(type_)
+        key_type, items_type = args if args else (typing.Any, typing.Any)
         key_type = _maybe_resolve_forward_ref(key_type, host)
         items_type = _maybe_resolve_forward_ref(items_type, host)
         d = {

--- a/tests/test_unchecked_base_model.py
+++ b/tests/test_unchecked_base_model.py
@@ -1,0 +1,11 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from cohere.core.unchecked_base_model import construct_type
+
+
+def test_construct_type_bare_dict_no_unpack_error():
+    # bare dict (unparameterized) must not raise ValueError on get_args unpacking
+    result = construct_type(type_=dict, object_={"key": "value"})
+    assert result == {"key": "value"}


### PR DESCRIPTION
## What's broken

Calling `construct_type(type_=dict, object_={...})` raises `ValueError: not enough values to unpack (expected 2, got 0)`. Any Pydantic model field annotated as bare `dict` (rather than `Dict[str, Any]`) triggers this crash during deserialization.

## Why it happens

`get_args(dict)` returns an empty tuple, so the two-target unpacking `key_type, items_type = get_args(type_)` fails when no type parameters are present.

## Fix

Replace the bare unpacking with `args = get_args(type_); key_type, items_type = args if args else (typing.Any, typing.Any)`. This makes a bare `dict` behave identically to `Dict[Any, Any]`.

## Test

Added `tests/test_unchecked_base_model.py::test_construct_type_bare_dict_no_unpack_error` which calls `construct_type` with `type_=dict` and asserts the result equals the input dict without raising.

Fixes #774

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in deserialization coercion plus a unit test; no auth, security, or API contract changes.
> 
> **Overview**
> Fixes a crash in **`construct_type`** when the declared type is an unparameterized **`dict`**. **`get_args(dict)`** is empty, so unpacking into key/value element types raised **`ValueError`** during model construction/deserialization for fields typed as bare **`dict`**.
> 
> The change reads type parameters from **`get_args`** and, when none are present, treats the mapping as **`Dict[Any, Any]`** (keys and values passed through **`construct_type`** without failing). A regression test asserts **`construct_type(type_=dict, object_={...})`** returns the input mapping unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6db0dd19db8d8db13597a99e0d26cf06f52041c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->