### PR TITLE
ci: pin GitHub Actions to full commit SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
       - name: Bootstrap poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
         with:
           version: 1.5.1
           virtualenvs-in-project: false
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
       - name: Bootstrap poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
         with:
           version: 1.5.1
           virtualenvs-in-project: false
@@ -56,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
       - name: Bootstrap poetry


### PR DESCRIPTION
## Summary

Pins all GitHub Actions in the CI workflow to full commit SHAs instead of mutable version tags.

## Vulnerability

Using mutable tags like `@v3`, `@v4`, `@v1` means the action code can change without any notice — a compromised or malicious update to the action repository could silently alter what runs in CI. This is a common supply-chain attack vector (see [tj-actions/changed-files incident](https://github.com/orgs/community/discussions/182)).

## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v3` | `@f43a0e5` (v3) |
| `actions/setup-python` | `@v4` | `@7f4fc3e` (v4) |
| `snok/install-poetry` | `@v1` | `@a783c32` (v1) |

All pins point to the exact same version as before — behaviour is unchanged. The human-readable version comment is kept for readability.

## References
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only supply-chain hardening; no application, auth, or data-path changes.
> 
> **Overview**
> **Hardens CI** by replacing mutable action tags (`@v3`, `@v4`, `@v1`) with **immutable full commit SHAs** for `actions/checkout`, `actions/setup-python`, and `snok/install-poetry` in the **compile**, **test**, and **publish** jobs in `.github/workflows/ci.yml`.
> 
> Each pin keeps a **version comment** (e.g. `# v3`) so upgrades stay readable. **Runtime behavior is unchanged**—the SHAs match the same releases that were referenced by the tags before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b407fb72071b58c757d11f2fb4d4d0a84376f8ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->