### PR TITLE
fix: avoid writing None AWS region to environment

### DIFF
--- a/src/cohere/manually_maintained/cohere_aws/client.py
+++ b/src/cohere/manually_maintained/cohere_aws/client.py
@@ -3,18 +3,19 @@ import os
 import tarfile
 import tempfile
 import time
+import typing
 from typing import Any, Dict, List, Optional, Union
 
+from ..lazy_aws_deps import lazy_boto3, lazy_botocore, lazy_sagemaker
+from .chat import Chat, StreamingChat
 from .classification import Classification, Classifications
 from .embeddings import Embeddings
 from .error import CohereError
 from .generation import Generations, StreamingGenerations
-from .chat import Chat, StreamingChat
+from .mode import Mode
 from .rerank import Reranking
 from .summary import Summary
-from .mode import Mode
-import typing
-from ..lazy_aws_deps import lazy_boto3, lazy_botocore, lazy_sagemaker
+
 
 class Client:
     def __init__(
@@ -27,7 +28,7 @@ class Client:
         `aws configure set region us-west-2` or override it with `region_name` parameter.
         """
         self.mode = mode
-        if os.environ.get('AWS_DEFAULT_REGION') is None:
+        if os.environ.get('AWS_DEFAULT_REGION') is None and aws_region is not None:
             os.environ['AWS_DEFAULT_REGION'] = aws_region
 
         if self.mode == Mode.SAGEMAKER:

--- a/tests/test_aws_client_unit.py
+++ b/tests/test_aws_client_unit.py
@@ -128,6 +128,22 @@ class TestModeConditionalInit(unittest.TestCase):
         sig = inspect.signature(Client.__init__)
         self.assertEqual(sig.parameters["mode"].default, Mode.SAGEMAKER)
 
+    def test_missing_region_does_not_write_none_to_environment(self) -> None:
+        """No aws_region + unset AWS_DEFAULT_REGION should not crash before boto3 resolves defaults."""
+        mock_boto3 = MagicMock()
+        mock_sagemaker = MagicMock()
+
+        with patch("cohere.manually_maintained.cohere_aws.client.lazy_boto3", return_value=mock_boto3), \
+             patch("cohere.manually_maintained.cohere_aws.client.lazy_sagemaker", return_value=mock_sagemaker), \
+             patch.dict(os.environ, {}, clear=True):
+
+            from cohere.manually_maintained.cohere_aws.client import Client
+
+            Client()
+
+            self.assertNotIn("AWS_DEFAULT_REGION", os.environ)
+            self.assertEqual(mock_boto3.client.call_args_list[0].kwargs["region_name"], None)
+
 
 class TestEmbedV4Params(unittest.TestCase):
     """Fix 3: embed() should accept output_dimension and embedding_types,


### PR DESCRIPTION
## Summary

Fix the manually maintained AWS client so constructing `cohere.manually_maintained.cohere_aws.client.Client()` without an explicit `aws_region` no longer writes `None` into `AWS_DEFAULT_REGION`.

When both `aws_region` and `AWS_DEFAULT_REGION` were unset, the client attempted:

```python
os.environ["AWS_DEFAULT_REGION"] = None
```

which raises `TypeError: str expected, not NoneType` before boto3 can resolve its normal region provider chain. This change only writes the environment variable when `aws_region` is provided.

## Test Plan

- [x] `pytest -q tests/test_aws_client_unit.py`
- [x] `pytest -q tests/test_aws_client_unit.py tests/test_embed_utils.py tests/test_embed_streaming.py`
- [x] `ruff check src/cohere/manually_maintained/cohere_aws/client.py tests/test_aws_client_unit.py`
- [x] `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow init guard around environment mutation; behavior unchanged when an explicit region is passed.
> 
> **Overview**
> Fixes a crash when constructing `cohere.manually_maintained.cohere_aws.client.Client()` without `aws_region` and with `AWS_DEFAULT_REGION` unset. The client previously always assigned `os.environ['AWS_DEFAULT_REGION'] = aws_region`, which raised `TypeError` when `aws_region` was `None`. It now **only** sets that env var when `aws_region` is provided, so boto3 can use its normal region resolution chain.
> 
> Adds a unit test that clears the environment, constructs `Client()` with no region, and asserts `AWS_DEFAULT_REGION` is not set while boto3 still receives `region_name=None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bfbf1761deb6d6a556b83693a4371def0e88239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->