### PR TITLE
fix(utils): batched embed drops meta.tokens and image billed units

### DIFF
--- a/src/cohere/utils.py
+++ b/src/cohere/utils.py
@@ -9,7 +9,7 @@ import requests
 from fastavro import parse_schema, reader, writer
 
 from . import EmbedResponse, EmbeddingsFloatsEmbedResponse, EmbeddingsByTypeEmbedResponse, ApiMeta, \
-    EmbedByTypeResponseEmbeddings, ApiMetaBilledUnits, EmbedJob, CreateEmbedJobResponse, Dataset
+    EmbedByTypeResponseEmbeddings, ApiMetaBilledUnits, ApiMetaTokens, EmbedJob, CreateEmbedJobResponse, Dataset
 from .datasets import DatasetsCreateResponse, DatasetsGetResponse
 from .overrides import get_fields
 
@@ -170,19 +170,37 @@ def sum_fields_if_not_none(obj: typing.Any, field: str) -> Optional[int]:
 def merge_meta_field(metas: typing.List[ApiMeta]) -> ApiMeta:
     api_version = metas[0].api_version if metas else None
     billed_units = [meta.billed_units for meta in metas]
+    images = sum_fields_if_not_none(billed_units, "images")
     input_tokens = sum_fields_if_not_none(billed_units, "input_tokens")
+    image_tokens = sum_fields_if_not_none(billed_units, "image_tokens")
     output_tokens = sum_fields_if_not_none(billed_units, "output_tokens")
     search_units = sum_fields_if_not_none(billed_units, "search_units")
     classifications = sum_fields_if_not_none(billed_units, "classifications")
+
+    token_counts = [meta.tokens for meta in metas]
+    token_input = sum_fields_if_not_none(token_counts, "input_tokens")
+    token_output = sum_fields_if_not_none(token_counts, "output_tokens")
+    # Leave tokens unset rather than building an all-None ApiMetaTokens, so a
+    # merged response is indistinguishable from an unbatched one.
+    tokens = ApiMetaTokens(
+        input_tokens=token_input,
+        output_tokens=token_output,
+    ) if token_input is not None or token_output is not None else None
+
+    cached_tokens = sum_fields_if_not_none(metas, "cached_tokens")
     warnings = {warning for meta in metas if meta.warnings for warning in meta.warnings}
     return ApiMeta(
         api_version=api_version,
         billed_units=ApiMetaBilledUnits(
+            images=images,
             input_tokens=input_tokens,
+            image_tokens=image_tokens,
             output_tokens=output_tokens,
             search_units=search_units,
             classifications=classifications
         ),
+        tokens=tokens,
+        cached_tokens=cached_tokens,
         warnings=list(warnings)
     )
 

--- a/tests/test_embed_utils.py
+++ b/tests/test_embed_utils.py
@@ -1,8 +1,9 @@
 import unittest
 
 from cohere import EmbeddingsByTypeEmbedResponse, EmbedByTypeResponseEmbeddings, ApiMeta, ApiMetaBilledUnits, \
-    ApiMetaApiVersion, EmbeddingsFloatsEmbedResponse
-from cohere.utils import merge_embed_responses, sum_fields_if_not_none
+    ApiMetaApiVersion, ApiMetaTokens, EmbeddingsFloatsEmbedResponse
+from cohere.overrides import get_fields
+from cohere.utils import merge_embed_responses, merge_meta_field, sum_fields_if_not_none
 
 ebt_1 = EmbeddingsByTypeEmbedResponse(
     response_type="embeddings_by_type",
@@ -204,6 +205,66 @@ class TestClient(unittest.TestCase):
             embeddings=EmbedByTypeResponseEmbeddings(float_=None))
         result = merge_embed_responses([resp1, resp2])
         self.assertEqual(result.embeddings.float_, [[1.0, 2.0]])  # type: ignore
+
+    def test_merge_meta_field_keeps_tokens_and_image_units(self) -> None:
+        merged = merge_meta_field([
+            ApiMeta(
+                api_version=ApiMetaApiVersion(version="1"),
+                billed_units=ApiMetaBilledUnits(input_tokens=1, images=1, image_tokens=10),
+                tokens=ApiMetaTokens(input_tokens=11, output_tokens=0),
+                cached_tokens=3,
+            ),
+            ApiMeta(
+                api_version=ApiMetaApiVersion(version="1"),
+                billed_units=ApiMetaBilledUnits(input_tokens=2, images=2, image_tokens=20),
+                tokens=ApiMetaTokens(input_tokens=22, output_tokens=0),
+                cached_tokens=4,
+            ),
+        ])
+
+        if merged.billed_units is None or merged.tokens is None:
+            raise Exception("this is just for mypy")
+
+        self.assertEqual(merged.billed_units.input_tokens, 3)
+        self.assertEqual(merged.billed_units.images, 3)
+        self.assertEqual(merged.billed_units.image_tokens, 30)
+        self.assertEqual(merged.tokens.input_tokens, 33)
+        self.assertEqual(merged.tokens.output_tokens, 0)
+        self.assertEqual(merged.cached_tokens, 7)
+
+    def test_merge_meta_field_leaves_tokens_unset_when_absent(self) -> None:
+        merged = merge_meta_field([
+            ApiMeta(billed_units=ApiMetaBilledUnits(input_tokens=1)),
+            ApiMeta(billed_units=ApiMetaBilledUnits(input_tokens=2)),
+        ])
+
+        self.assertIsNone(merged.tokens)
+        self.assertIsNone(merged.cached_tokens)
+
+    def test_merge_meta_field_sums_every_numeric_field_on_the_model(self) -> None:
+        # merge_meta_field lists the fields it copies by hand, so any field added
+        # to ApiMeta later is silently dropped from every merged response until
+        # someone remembers to update it. That is how images, image_tokens,
+        # tokens and cached_tokens went missing. Drive the assertion off the
+        # model itself so the next added field fails here instead of in the wild.
+        billed_fields = get_fields(ApiMetaBilledUnits())
+        token_fields = get_fields(ApiMetaTokens())
+        meta = ApiMeta(
+            billed_units=ApiMetaBilledUnits(**{field: 1 for field in billed_fields}),
+            tokens=ApiMetaTokens(**{field: 1 for field in token_fields}),
+            cached_tokens=1,
+        )
+
+        merged = merge_meta_field([meta, meta])
+
+        if merged.billed_units is None or merged.tokens is None:
+            raise Exception("this is just for mypy")
+
+        for field in billed_fields:
+            self.assertEqual(getattr(merged.billed_units, field), 2, f"billed_units.{field} was dropped")
+        for field in token_fields:
+            self.assertEqual(getattr(merged.tokens, field), 2, f"tokens.{field} was dropped")
+        self.assertEqual(merged.cached_tokens, 2)
 
     def test_sum_fields_if_not_none_with_none_entries(self) -> None:
         # billed_units list may contain None when ApiMeta.billed_units is unset;


### PR DESCRIPTION
`Client.embed()` goes through `merge_embed_responses` on every call unless you pass `batching=False` or pass images, and that path rebuilds `ApiMeta` from scratch inside `merge_meta_field`. The rebuild sets `api_version`, four of the six `ApiMetaBilledUnits` fields, and `warnings`. Everything else on the metadata is dropped on the floor: `meta.tokens`, `meta.cached_tokens`, `billed_units.images` and `billed_units.image_tokens`.

Since `batching` defaults to `True`, the default path is the lossy one:

```python
co.embed(texts=texts).meta.tokens                  # None
co.embed(texts=texts, batching=False).meta.tokens  # populated
```

Same request, different metadata, and nothing in the signature suggests that a batching flag should change which usage numbers come back. Anyone reading `meta.tokens` for accounting gets `None` and no error to tell them why.

The fix sums the four missing fields exactly the way the existing four are summed. `cached_tokens` sits directly on `ApiMeta` rather than under `billed_units`, so it sums off the meta list instead of the billed units list.

One deliberate choice worth flagging: `tokens` stays `None` when none of the input metas carried it, rather than building an `ApiMetaTokens(None, None)`. A merged response with no token counts then looks exactly like it does today, which is why the existing equality assertions in `test_embed_utils.py` did not need touching.

### Why this happened, and stopping it happening again

`merge_meta_field` lists the fields it copies by hand. `images`, `image_tokens`, `tokens` and `cached_tokens` were added to the models and the merge was never updated, and nothing failed. The same thing will happen to the next field added.

So one of the three tests drives its assertions off the model fields rather than a hardcoded list:

```python
billed_fields = get_fields(ApiMetaBilledUnits())
...
for field in billed_fields:
    self.assertEqual(getattr(merged.billed_units, field), 2, f"billed_units.{field} was dropped")
```

Add a field to `ApiMetaBilledUnits` or `ApiMetaTokens` without touching `merge_meta_field` and that test fails immediately. I verified it fails on `main` as it stands.

The other two are ordinary: `test_merge_meta_field_keeps_tokens_and_image_units` covers the summing and uses `output_tokens=0` on both inputs so a falsy value is not confused with an absent one, and `test_merge_meta_field_leaves_tokens_unset_when_absent` pins the `None` behaviour so it does not get simplified away later.

### Notes

- Only `src/cohere/utils.py` and `tests/` are touched, both listed in `.fernignore`.
- `mypy .` clean across 341 files, `tests/test_embed_utils.py` 9 passed.
- I originally included a `7.0.8 -> 7.0.9` bump following #778 and #779 and have dropped it. I have a second fix open against `utils.py` at the same time and they cannot both bump to the same version, and `core/client_wrapper.py` is Fern generated rather than hand maintained, so the version looks like yours to set at release. Say the word if you would rather the bump were in here and I will add it back.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to embed response merging and tests; fixes incorrect metadata rather than altering auth or API contracts.
> 
> **Overview**
> **Fixes silent loss of usage metadata** when `Client.embed()` merges multiple batch responses (default `batching=True`). `merge_meta_field` now sums **`billed_units.images`**, **`billed_units.image_tokens`**, **`meta.tokens`** (input/output), and **`cached_tokens`** alongside the fields it already merged, so batched calls return the same usage shape as a single request.
> 
> **`tokens` stays `None`** when no input meta had token counts (no empty `ApiMetaTokens`), keeping merged responses aligned with unbatched ones when token data was never present.
> 
> **Tests** cover image/token summing, absent-token behavior, and a model-driven check that every numeric field on `ApiMetaBilledUnits` / `ApiMetaTokens` is merged so future model fields cannot be dropped without failing CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0878e27d22e2fd7c996ab9e0710d9567fe48605f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->