### PR TITLE
fix(utils): save_csv writes a blank row between every record on Windows

### DIFF
--- a/src/cohere/utils.py
+++ b/src/cohere/utils.py
@@ -266,7 +266,8 @@ def save_jsonl(dataset: Dataset, filepath: str):
 
 
 def save_csv(dataset: Dataset, filepath: str):
-    with open(filepath, "w") as outfile:
+    # csv writes its own \r\n, so the stream must not translate newlines again.
+    with open(filepath, "w", newline="") as outfile:
         for i, data in enumerate(dataset_generator(dataset)):
             if i == 0:
                 writer = csv.DictWriter(outfile, fieldnames=list(data.keys()))

--- a/tests/test_save_dataset.py
+++ b/tests/test_save_dataset.py
@@ -1,0 +1,49 @@
+import csv
+import os
+import tempfile
+import typing
+import unittest
+from unittest import mock
+
+from cohere.utils import save_csv
+
+records: typing.List[typing.Dict[str, str]] = [
+    {"text": "hello", "label": "a"},
+    {"text": "goodbye", "label": "b"},
+]
+
+
+class TestSaveCsv(unittest.TestCase):
+
+    def _write(self, path: str) -> bytes:
+        with mock.patch("cohere.utils.dataset_generator", return_value=iter(records)):
+            save_csv(mock.Mock(), path)
+        with open(path, "rb") as f:
+            return f.read()
+
+    def test_save_csv_uses_a_single_crlf_per_row(self) -> None:
+        # csv.DictWriter terminates rows with \r\n on every platform. If the
+        # stream also translates newlines the file ends up with \r\r\n, which
+        # readers see as a blank row between every record.
+        with tempfile.TemporaryDirectory() as tmp:
+            raw = self._write(os.path.join(tmp, "out.csv"))
+
+        self.assertEqual(raw, b"text,label\r\nhello,a\r\ngoodbye,b\r\n")
+
+    def test_save_csv_round_trips(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "out.csv")
+            self._write(path)
+            with open(path, newline="") as f:
+                self.assertEqual(list(csv.DictReader(f)), records)
+
+    def test_save_csv_disables_newline_translation_on_the_stream(self) -> None:
+        # The two tests above only fail on a platform whose text streams
+        # translate newlines, so on Linux CI they pass either way. Assert the
+        # open call directly as well, otherwise nothing here guards against the
+        # newline argument being dropped again.
+        with mock.patch("cohere.utils.dataset_generator", return_value=iter(records)), \
+                mock.patch("cohere.utils.open", mock.mock_open(), create=True) as opened:
+            save_csv(mock.Mock(), "out.csv")
+
+        self.assertEqual(opened.call_args.kwargs.get("newline"), "")


### PR DESCRIPTION
`save_dataset(format="csv")` opens the file with `open(filepath, "w")` and hands it to `csv.DictWriter`. `DictWriter` terminates every row with `\r\n` itself, and on Windows a text stream then translates that `\n` into `\r\n` as well, so every row ends up terminated with `\r\r\n`.

```python
>>> save_csv(dataset, "out.csv")
>>> open("out.csv", "rb").read()
b'text,label\r\r\nhello,a\r\r\ngoodbye,b\r\r\n'
>>> open("out.csv").readlines()
['text,label\n', '\n', 'hello,a\n', '\n', 'goodbye,b\n', '\n']
```

Python's own `csv` reader copes with it, so a round trip back through the SDK looks fine and the damage only shows up downstream. Excel renders a blank row after every record, and `pandas.read_csv` gives back rows of `NaN` unless `skip_blank_lines` is set.

The csv docs call this out directly: the file has to be opened with `newline=""`. That is the whole change. `save_avro` already opens in binary so it was never affected, and I left `save_jsonl` alone since it writes its own separator and is a different question.

### On the tests, because this one is awkward to guard

The bug only reproduces on a platform whose text streams translate newlines. On Linux the unfixed code writes correct bytes, so any test that inspects the file passes with or without the fix and your CI would be guarding nothing.

So there are three. Two inspect the file, assert exact bytes rather than counting blank rows since that states the real contract, and fail on Windows without the change. The third asserts the `open` call itself:

```python
self.assertEqual(opened.call_args.kwargs.get("newline"), "")
```

That one fails on every platform, so Linux CI actually catches it if the argument is ever dropped again. Testing the call rather than the output is not something I would normally reach for, and the test carries a comment saying why. Happy to drop it if you would rather not couple a test to the call shape.

Verified in both directions locally: the byte tests and the `open` test both fail on `main` and pass with the change.

### Notes

- Only `src/cohere/utils.py` and `tests/` are touched, both listed in `.fernignore`.
- `mypy .` clean across 342 files, `tests/test_save_dataset.py` 3 passed.
- I originally included a `7.0.8 -> 7.0.9` bump following #778 and #779 and have dropped it. I have a second fix open against `utils.py` at the same time and they cannot both bump to the same version, and `core/client_wrapper.py` is Fern generated rather than hand maintained, so the version looks like yours to set at release. Say the word if you would rather the bump were in here and I will add it back.
- Adjacent and deliberately not fixed here: `save_csv` and `save_jsonl` both open in text mode without `encoding`, so they use the locale default and will raise `UnicodeEncodeError` on a Windows machine for any dataset containing non cp1252 text. Happy to send that separately if it is worth having.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CSV file writing plus tests; no auth, security, or API contract changes.
> 
> **Overview**
> Fixes **CSV dataset export on Windows** where `save_csv` / `save_dataset(format="csv")` could write `\r\r\n` row endings because `csv.DictWriter` already emits `\r\n` and the text stream translated newlines again. Exports now open the output file with **`newline=""`**, matching Python’s `csv` guidance so each row has a single CRLF.
> 
> Adds **`tests/test_save_dataset.py`** with byte-level expectations, a `csv.DictReader` round-trip, and a mocked assertion that `open(..., newline="")` is used so Linux CI still catches regressions if the argument is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa3702cce282affcec6160cc9241cf1cc47a4499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->