### PR TITLE
Omit Authorization header when api_key is empty

### DIFF
--- a/.fern/metadata.json
+++ b/.fern/metadata.json
@@ -103,7 +103,7 @@
   "originGitCommit": "3f4bc18b3d90a318965a1fc2f5980339c012a6e2",
   "originGitCommitIsDirty": true,
   "invokedBy": "ci",
-  "requestedVersion": "7.0.8",
+  "requestedVersion": "7.0.9",
   "ciProvider": "github",
-  "sdkVersion": "7.0.8"
+  "sdkVersion": "7.0.9"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "cohere"
-version = "7.0.8"
+version = "7.0.9"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/cohere/core/client_wrapper.py
+++ b/src/cohere/core/client_wrapper.py
@@ -35,12 +35,12 @@ class BaseClientWrapper:
         import platform
 
         headers: typing.Dict[str, str] = {
-            "User-Agent": "cohere/7.0.8",
+            "User-Agent": "cohere/7.0.9",
             "X-Fern-Language": "Python",
             "X-Fern-Runtime": f"python/{platform.python_version()}",
             "X-Fern-Platform": f"{platform.system().lower()}/{platform.release()}",
             "X-Fern-SDK-Name": "cohere",
-            "X-Fern-SDK-Version": "7.0.8",
+            "X-Fern-SDK-Version": "7.0.9",
             **(self.get_custom_headers() or {}),
         }
         if self._client_name is not None:

--- a/src/cohere/overrides.py
+++ b/src/cohere/overrides.py
@@ -59,11 +59,46 @@ def make_tool_call_v2_id_optional(cls):
     return cls
 
 
+def omit_authorization_header_when_api_key_is_empty() -> None:
+    """
+    Do not send an `Authorization` header when the client is created with an empty API key.
+
+    This allows pointing the client at a proxy or a self-hosted deployment that performs its own
+    authentication, e.g. `cohere.Client(api_key="")`.
+    """
+    from .core.client_wrapper import AsyncClientWrapper, BaseClientWrapper
+
+    if getattr(BaseClientWrapper, "_omits_empty_authorization", False):
+        return
+
+    get_headers = BaseClientWrapper.get_headers
+    async_get_headers = AsyncClientWrapper.async_get_headers
+
+    def patched_get_headers(self: BaseClientWrapper) -> typing.Dict[str, str]:
+        headers = get_headers(self)
+        if not self._get_token():
+            headers.pop("Authorization", None)
+        return headers
+
+    async def patched_async_get_headers(self: AsyncClientWrapper) -> typing.Dict[str, str]:
+        headers = await async_get_headers(self)
+        if headers.get("Authorization") == "Bearer ":
+            headers.pop("Authorization", None)
+        return headers
+
+    BaseClientWrapper.get_headers = patched_get_headers  # type: ignore[method-assign]
+    AsyncClientWrapper.async_get_headers = patched_async_get_headers  # type: ignore[method-assign]
+    BaseClientWrapper._omits_empty_authorization = True  # type: ignore[attr-defined]
+
+
 def run_overrides():
     """
         These are overrides to allow us to make changes to generated code without touching the generated files themselves.
         Should be used judiciously!
     """
+
+    # Override to skip the Authorization header entirely when an empty api_key is passed
+    omit_authorization_header_when_api_key_is_empty()
 
     # Override to allow access to aliases in EmbedByTypeResponseEmbeddings eg embeddings.float rather than embeddings.float_
     setattr(EmbedByTypeResponseEmbeddings, "__getattr__", allow_access_to_aliases)

--- a/src/cohere/overrides.py
+++ b/src/cohere/overrides.py
@@ -76,7 +76,10 @@ def omit_authorization_header_when_api_key_is_empty() -> None:
 
     def patched_get_headers(self: BaseClientWrapper) -> typing.Dict[str, str]:
         headers = get_headers(self)
-        if not self._get_token():
+        # Inspect the header that get_headers() already built rather than calling _get_token()
+        # again: for the callable `api_key` form that would invoke the supplier twice per request,
+        # and a supplier whose value changes between the two calls would produce the wrong header.
+        if headers.get("Authorization") == "Bearer ":
             headers.pop("Authorization", None)
         return headers
 

--- a/tests/test_optional_auth.py
+++ b/tests/test_optional_auth.py
@@ -29,3 +29,21 @@ class TestOptionalAuth(unittest.TestCase):
 
     def test_callable_api_key_returning_empty_string_omits_authorization_header(self) -> None:
         self.assertNotIn("Authorization", _headers(cohere.Client(api_key=lambda: "")))
+
+    def test_callable_api_key_is_invoked_once_per_request(self) -> None:
+        calls = 0
+
+        def api_key() -> str:
+            nonlocal calls
+            calls += 1
+            return "n/a"
+
+        self.assertEqual(_headers(cohere.Client(api_key=api_key))["Authorization"], "Bearer n/a")
+        self.assertEqual(calls, 1)
+
+    def test_callable_api_key_is_not_re_read_after_the_header_is_built(self) -> None:
+        # A supplier whose value changes between calls must not be able to strip an Authorization
+        # header that was built from a valid token.
+        values = iter(["real-token", ""])
+        client = cohere.Client(api_key=lambda: next(values))
+        self.assertEqual(_headers(client)["Authorization"], "Bearer real-token")

--- a/tests/test_optional_auth.py
+++ b/tests/test_optional_auth.py
@@ -1,0 +1,31 @@
+import asyncio
+import typing
+import unittest
+
+import cohere
+
+
+def _headers(client: typing.Any) -> typing.Dict[str, str]:
+    return client._client_wrapper.get_headers()
+
+
+async def _async_headers(client: typing.Any) -> typing.Dict[str, str]:
+    return await client._client_wrapper.async_get_headers()
+
+
+class TestOptionalAuth(unittest.TestCase):
+    def test_empty_api_key_omits_authorization_header(self) -> None:
+        self.assertNotIn("Authorization", _headers(cohere.Client(api_key="")))
+        self.assertNotIn("Authorization", _headers(cohere.ClientV2(api_key="")))
+        self.assertNotIn("Authorization", asyncio.run(_async_headers(cohere.AsyncClient(api_key=""))))
+        self.assertNotIn("Authorization", asyncio.run(_async_headers(cohere.AsyncClientV2(api_key=""))))
+
+    def test_api_key_is_sent_when_provided(self) -> None:
+        self.assertEqual(_headers(cohere.Client(api_key="n/a"))["Authorization"], "Bearer n/a")
+        self.assertEqual(_headers(cohere.ClientV2(api_key="n/a"))["Authorization"], "Bearer n/a")
+        self.assertEqual(
+            asyncio.run(_async_headers(cohere.AsyncClient(api_key="n/a")))["Authorization"], "Bearer n/a"
+        )
+
+    def test_callable_api_key_returning_empty_string_omits_authorization_header(self) -> None:
+        self.assertNotIn("Authorization", _headers(cohere.Client(api_key=lambda: "")))


### PR DESCRIPTION
This PR comes from Fern.

## Motivation

Some users point the Python SDK at a proxy or a self-hosted deployment that performs its own authentication upstream. In that setup there is no Cohere API key to supply, but the client always sends an `Authorization` header. Passing an empty key produces a literal `Authorization: Bearer ` header, which some proxies reject outright rather than ignore.

This makes an empty `api_key` mean "don't send the header at all":

```python
client = cohere.Client(api_key="", base_url="https://my-proxy.example.com")
```

## Changes

Adds `omit_authorization_header_when_api_key_is_empty()` to `src/cohere/overrides.py`, wired into `run_overrides()`. It patches `BaseClientWrapper.get_headers` and `AsyncClientWrapper.async_get_headers` so that an empty resolved `api_key` results in no `Authorization` header.

Both patches work by inspecting the header that `get_headers()` has already built, rather than re-resolving the key. That keeps the `api_key` supplier resolved exactly once per request, which matters because `api_key` is documented as accepting a callable: a supplier is invoked a single time, and one whose value changes between calls cannot produce a header that disagrees with the token actually used.

The patch is idempotent, guarded by an `_omits_empty_authorization` marker, so repeated `run_overrides()` calls do not stack wrappers.

Behaviour is unchanged whenever a key is present: a real key still yields `Authorization: Bearer <key>`, and `api_key=None` still falls back to the `CO_API_KEY` environment variable.

No `.fernignore` change is needed — `src/cohere/overrides.py` and `tests` are both already listed there, so regeneration will not clobber these files.

## Testing

Adds `tests/test_optional_auth.py` — 5 tests, no network access or API key required:

- an empty `api_key` omits the header for `Client`, `ClientV2`, `AsyncClient` and `AsyncClientV2`
- a provided key is still sent as `Bearer <key>`
- a callable returning `""` omits the header
- a callable supplier is invoked exactly once per request
- a supplier whose value changes between calls cannot strip a header built from a valid token

Verified locally: `test_optional_auth.py`, `test_overrides.py`, `test_client_init.py`, `test_embed_streaming.py` and `test_embed_utils.py` pass (22 passed, 1 skipped), and `mypy` is clean on both changed files. The live-API test modules were not run locally as they require credentials; CI covers those.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every HTTP request builds auth headers for all client types; behavior for non-empty keys is unchanged but empty-key and callable-supplier paths are security-sensitive.
> 
> **Overview**
> **Bumps the SDK to 7.0.9** (metadata, `pyproject.toml`, and client `User-Agent` / Fern headers).
> 
> **Empty `api_key` no longer sends `Authorization`.** A new override in `overrides.py` patches sync and async header builders so `Authorization: Bearer ` is removed when the resolved key is empty—supporting proxies/self-hosted endpoints that authenticate elsewhere via `cohere.Client(api_key="")`. Patches inspect the already-built header (not a second token resolution) so callable `api_key` suppliers run once per request. The patch is idempotent via `_omits_empty_authorization`.
> 
> **Adds `tests/test_optional_auth.py`** covering Client/V2 and async clients, callable keys, and single-invocation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0602c006173a098f2c470672316988848abbd06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->