### PR TITLE
fix(utils): preserve embedding types across batches

### DIFF
--- a/src/cohere/utils.py
+++ b/src/cohere/utils.py
@@ -224,8 +224,13 @@ def merge_embed_responses(responses: typing.List[EmbedResponse]) -> EmbedRespons
             for response in embeddings_type
         ]
 
-        # only get set keys from the pydantic model (i.e. exclude fields that are set to 'None')
-        fields = [x for x in get_fields(embeddings_type[0].embeddings) if getattr(embeddings_type[0].embeddings, x) is not None]
+        # Include a type when any batch returned it. Looking only at the first
+        # response can silently discard valid embeddings from later batches.
+        fields = [
+            field
+            for field in get_fields(embeddings_type[0].embeddings)
+            if any(getattr(response.embeddings, field) is not None for response in embeddings_type)
+        ]
 
         merged_dicts = {
             field: [

--- a/tests/test_embed_utils.py
+++ b/tests/test_embed_utils.py
@@ -205,6 +205,20 @@ class TestClient(unittest.TestCase):
         result = merge_embed_responses([resp1, resp2])
         self.assertEqual(result.embeddings.float_, [[1.0, 2.0]])  # type: ignore
 
+    def test_merge_embeddings_by_type_keeps_field_from_later_response(self) -> None:
+        resp1 = EmbeddingsByTypeEmbedResponse(
+            response_type="embeddings_by_type", id="1",
+            embeddings=EmbedByTypeResponseEmbeddings(float_=[[1.0, 2.0]]))
+        resp2 = EmbeddingsByTypeEmbedResponse(
+            response_type="embeddings_by_type", id="2",
+            embeddings=EmbedByTypeResponseEmbeddings(
+                float_=[[3.0, 4.0]], int8=[[3, 4]]))
+
+        result = merge_embed_responses([resp1, resp2])
+
+        self.assertEqual(result.embeddings.float_, [[1.0, 2.0], [3.0, 4.0]])  # type: ignore
+        self.assertEqual(result.embeddings.int8, [[3, 4]])  # type: ignore
+
     def test_sum_fields_if_not_none_with_none_entries(self) -> None:
         # billed_units list may contain None when ApiMeta.billed_units is unset;
         # sum_fields_if_not_none must skip None objects without raising AttributeError


### PR DESCRIPTION
Fixes #796

## Summary

- collect embedding types from every batched response, not only the first
- continue skipping `None` values while preserving types returned by later batches
- add a regression for a later `int8` response

## Root cause

`merge_embed_responses()` built its field list from `embeddings_type[0]`. When that response did not contain a type that a later batch returned, the type was never added to the merged dictionary and its values were silently lost.

## Validation

- regression fails on `main` (`int8` is `None`)
- `pytest -q tests/test_embed_utils.py` (7 passed)
- `mypy .` (341 source files, no issues)
- `git diff --check`

The complete test collection requires `CO_API_KEY` in two existing modules, so no live API tests were run. Ruff reports the repository's existing import-format findings in both touched files; this patch does not reformat unrelated code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to batch merge logic with a regression test; affects embed response assembly only, not API calls or auth.
> 
> **Overview**
> Fixes batched **embeddings-by-type** merging so embedding types from later API batches are not dropped when the first batch did not return those types.
> 
> **`merge_embed_responses()`** now decides which fields to merge by checking whether **any** batch has a non-`None` value for each type, instead of only inspecting the first response. Merging still skips `None` per batch when concatenating vectors.
> 
> A regression test covers a case where the first batch has only `float_` and a later batch adds `int8`, ensuring both types appear in the merged result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9806f6455f14a824d742df03299b9391a7643645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->