### PR TITLE
fix(utils): close streamed dataset responses

### DIFF
--- a/src/cohere/utils.py
+++ b/src/cohere/utils.py
@@ -280,9 +280,9 @@ def dataset_generator(dataset: Dataset):
     for part in dataset.dataset_parts:
         if not part.url:
             raise ValueError("Dataset part does not have a url")
-        resp = requests.get(part.url, stream=True)
-        for record in reader(resp.raw): # type: ignore
-            yield record
+        with requests.get(part.url, stream=True) as resp:
+            for record in reader(resp.raw):  # type: ignore
+                yield record
 
 
 class SdkUtils:

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import cohere.utils
+from cohere import Dataset
+from cohere.utils import dataset_generator
+
+
+class TrackingResponse:
+    def __init__(self) -> None:
+        self.raw = object()
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __enter__(self) -> "TrackingResponse":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+
+def test_dataset_generator_closes_response_after_exhaustion(monkeypatch: Any) -> None:
+    response = TrackingResponse()
+    monkeypatch.setattr(cohere.utils.requests, "get", lambda *_args, **_kwargs: response)
+    monkeypatch.setattr(cohere.utils, "reader", lambda raw: iter([{"id": 1}]))
+    dataset = cast(Dataset, SimpleNamespace(dataset_parts=[SimpleNamespace(url="https://example.test/part.avro")]))
+
+    assert list(dataset_generator(dataset)) == [{"id": 1}]
+    assert response.closed
+
+
+def test_dataset_generator_closes_response_when_consumer_stops(monkeypatch: Any) -> None:
+    response = TrackingResponse()
+    monkeypatch.setattr(cohere.utils.requests, "get", lambda *_args, **_kwargs: response)
+    monkeypatch.setattr(cohere.utils, "reader", lambda raw: iter([{"id": 1}, {"id": 2}]))
+    dataset = cast(Dataset, SimpleNamespace(dataset_parts=[SimpleNamespace(url="https://example.test/part.avro")]))
+    records = dataset_generator(dataset)
+
+    assert next(records) == {"id": 1}
+    records.close()
+
+    assert response.closed


### PR DESCRIPTION
Fixes #798

## Summary

Close each streamed HTTP response used by `dataset_generator()` after its dataset part is exhausted or when the consumer closes the generator early.

## Root cause

The generator called `requests.get(..., stream=True)` and yielded records from the response body without ever closing the response. Repeated or multi-part dataset exports could therefore retain HTTP connections and file descriptors longer than intended.

## Fix

Use the response context manager around the existing Avro iteration. Streaming behavior, record ordering, and the public API remain unchanged.

## Tests

Two deterministic tests replace the network response and Avro reader with local tracking fakes. They verify closure after:

- normal generator exhaustion
- a consumer stops after one record and closes the generator

Validation:

- regression tests fail on `main` because both responses remain open
- focused dataset tests: 2 passed
- dataset and embedding utility tests: 8 passed
- MyPy: no issues in 342 source files
- Ruff passes for the new test
- `git diff --check` passes

The existing import block in `src/cohere/utils.py` continues to trigger its pre-existing Ruff `I001` finding; this patch does not reformat unrelated generated-era code. No external service, API key, or network request was used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Resource-cleanup change only; no auth, API, or data semantics changes. Behavior for callers who fully consume exports should match prior behavior with fewer held connections.
> 
> **Overview**
> **`dataset_generator()`** now wraps each `requests.get(..., stream=True)` call in a context manager so the HTTP response is closed when that dataset part finishes streaming or when the consumer closes the generator early.
> 
> That fixes leaked connections and file descriptors during repeated or multi-part dataset exports (`save_jsonl`, `save_csv`, `save_avro`). Streaming behavior, record ordering, and the public API are unchanged.
> 
> New tests in `tests/test_dataset_utils.py` use monkeypatched fakes to assert the response is closed after full iteration and after `generator.close()` after a single `next()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a45660f4cb879002c732cc5334fd85c263d876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->